### PR TITLE
GH-12: change hapi to get

### DIFF
--- a/python/rpkilog/rpkilog/hapi.py
+++ b/python/rpkilog/rpkilog/hapi.py
@@ -26,34 +26,27 @@ def aws_lambda_entry_point(event:dict, context:dict):
     )
     if not isinstance(event, dict):
         raise TypeError(f'event argument expected to be a dict but it is a {type(event)}')
-    if 'body' not in event:
-        raise KeyError('event argument is missing the "body" key')
-    if event.get('isBase64Encoded', False) == True:
-        body_plain = base64.b64decode(event['body'])
-    else:
-        body_plain = event['body']
-    body_dict = json.loads(body_plain)
 
     request_source_ip = event.get('requestContext', {}).get('http', {}).get('sourceIp', None)
-    logger.info(f'request from sourceIp {request_source_ip} body_dict: {body_dict}')
+    logger.info(f'request from sourceIp {request_source_ip} queryStringParameters: {event.queryStringParameters}')
 
     query_args = dict()
 
-    if 'asn' in body_dict:
-        query_args['asn'] = int(body_dict['asn'])
+    if 'asn' in event.queryStringParameters:
+        query_args['asn'] = int(event.queryStringParameters['asn'])
 
-    if 'exact' in body_dict:
-        query_args['exact'] = bool(body_dict['exact'])
+    if 'exact' in event.queryStringParameters:
+        query_args['exact'] = bool(event.queryStringParameters['exact'])
 
-    if 'max_len' in body_dict:
-        query_args['max_len'] = int(body_dict['max_len'])
+    if 'max_len' in event.queryStringParameters:
+        query_args['max_len'] = int(event.queryStringParameters['max_len'])
 
-    if 'prefix' in body_dict:
-        query_args['prefix'] = netaddr.IPNetwork(body_dict['prefix'])
+    if 'prefix' in event.queryStringParameters:
+        query_args['prefix'] = netaddr.IPNetwork(event.queryStringParameters['prefix'])
 
     for arg_name in ['observation_timestamp_start', 'observation_timestamp_end']:
-        if arg_name in body_dict:
-            query_args[arg_name] = date_parser.parse(body_dict[arg_name])
+        if arg_name in event.queryStringParameters:
+            query_args[arg_name] = date_parser.parse(event.queryStringParameters[arg_name])
 
     if not ('asn' in query_args or 'prefix' in query_args):
         return {

--- a/python/rpkilog/rpkilog/hapi.py
+++ b/python/rpkilog/rpkilog/hapi.py
@@ -28,25 +28,25 @@ def aws_lambda_entry_point(event:dict, context:dict):
         raise TypeError(f'event argument expected to be a dict but it is a {type(event)}')
 
     request_source_ip = event.get('requestContext', {}).get('http', {}).get('sourceIp', None)
-    logger.info(f'request from sourceIp {request_source_ip} queryStringParameters: {event.queryStringParameters}')
+    logger.info(f'request from sourceIp {request_source_ip} queryStringParameters: {event["queryStringParameters"]}')
 
     query_args = dict()
 
-    if 'asn' in event.queryStringParameters:
-        query_args['asn'] = int(event.queryStringParameters['asn'])
+    if 'asn' in event['queryStringParameters']:
+        query_args['asn'] = int(event['queryStringParameters']['asn'])
 
-    if 'exact' in event.queryStringParameters:
-        query_args['exact'] = bool(event.queryStringParameters['exact'])
+    if 'exact' in event['queryStringParameters']:
+        query_args['exact'] = bool(event['queryStringParameters']['exact'])
 
-    if 'max_len' in event.queryStringParameters:
-        query_args['max_len'] = int(event.queryStringParameters['max_len'])
+    if 'max_len' in event['queryStringParameters']:
+        query_args['max_len'] = int(event['queryStringParameters']['max_len'])
 
-    if 'prefix' in event.queryStringParameters:
-        query_args['prefix'] = netaddr.IPNetwork(event.queryStringParameters['prefix'])
+    if 'prefix' in event['queryStringParameters']:
+        query_args['prefix'] = netaddr.IPNetwork(event['queryStringParameters']['prefix'])
 
     for arg_name in ['observation_timestamp_start', 'observation_timestamp_end']:
-        if arg_name in event.queryStringParameters:
-            query_args[arg_name] = date_parser.parse(event.queryStringParameters[arg_name])
+        if arg_name in event['queryStringParameters']:
+            query_args[arg_name] = date_parser.parse(event['queryStringParameters'][arg_name])
 
     if not ('asn' in query_args or 'prefix' in query_args):
         return {

--- a/www/index.html
+++ b/www/index.html
@@ -35,7 +35,8 @@ helps you.</p>
     <input id="asn" value="" type="text" name="asn" size="7">
 
     <label for="observation_timestamp_start">Observed Date/Time Range From</label>
-    <input id="observation_timestamp_start" type="datetime-local" value="1981-01-01T00:00" min="1981-01-01T00:00" max="2038-01-01T00:00" name="observation_timestamp_start">
+    <input id="observation_timestamp_start" type="datetime-local" value="2020-01-01T00:00" min="1981-01-01T00:00" max="2038-01-01T00:00" name="observation_timestamp_start">
+
     <label for="observation_timestamp_end">To</label>
     <input id="observation_timestamp_end" type="datetime-local" value="2038-01-01T00:00" min="1981-01-01T00:00" max="2038-01-01T00:00" name="observation_timestamp_end">
 

--- a/www/main.js
+++ b/www/main.js
@@ -90,10 +90,12 @@ function search_clicked (event) {
         }
     }
 
-    fetch(rpkilog_config.api_url, {
-        method: 'POST',
+    let get_params = new URLSearchParams(query)
+    fetch(rpkilog_config.api_url + get_params.toString(), {
+        method: 'GET',
+        cache: 'no-store',
         headers: {'Accept': 'application/json'},
-        body: JSON.stringify(query),
+        mode: 'no-cors',
     })
     .then(fetch_response => fetch_response.json())
     .then(json_body => {


### PR DESCRIPTION
Changed the HTTP API from `GET` to `POST` method.

Updated the UI to use `GET` and to update the browser URL bar when search results are received.  This should make it easy to share links to search results.