### PR TITLE
GH-15: create apigw

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1218,6 +1218,18 @@ resource "aws_route53_record" "validate_acm_for_api_rpkilog_com" {
     zone_id = aws_route53_zone.rpkilog_com.zone_id
 }
 
+resource "aws_route53_record" "api_rpkilog_com" {
+    zone_id = aws_route53_zone.rpkilog_com.zone_id
+    name = "api.rpkilog.com"
+    type = "A"
+    alias {
+        evaluate_target_health = false
+        # If changing APIGW from REGIONAL to EDGE, the below should change from regional_ to cloudfront_.
+        name = aws_api_gateway_domain_name.api_rpkilog_com.regional_domain_name
+        zone_id = aws_api_gateway_domain_name.api_rpkilog_com.regional_zone_id
+    }
+}
+
 ##############################
 # Cloudfront
 
@@ -1301,6 +1313,8 @@ resource "aws_api_gateway_method_settings" "unstable" {
     ]
 }
 
+# In the AWS WWW Console, navigate to APIGW -> Custom domain names -> api.rpkilog.com -> API mappings
+# to understand how this applies.  Effectively, it maps api.rpkilog.com/unstable to aws_api_gateway_stage.unstable.
 resource "aws_api_gateway_base_path_mapping" "public_api" {
     api_id = aws_api_gateway_rest_api.public_api.id
     base_path = "unstable"

--- a/main.tf
+++ b/main.tf
@@ -933,6 +933,8 @@ resource "aws_lambda_function" "hapi" {
         ignore_changes = [ filename ]
     }
 }
+#FIXME: Correct permissions issues.  Currently, it is too permissive.
+#       See https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-permissions
 resource "aws_lambda_permission" "hapi_by_apigw" {
     # Allow APIGW to invoke the hapi lambda
     function_name = aws_lambda_function.hapi.function_name

--- a/python/rpkilog/rpkilog/hapi.py
+++ b/python/rpkilog/rpkilog/hapi.py
@@ -59,6 +59,10 @@ def aws_lambda_entry_point(event:dict, context:dict):
     # AWS REST API (APIGW 1.0) requires older response format
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response
     return {
+        'headers': {
+            'Access-Control-Allow-Methods': 'GET,OPTIONS,POST',
+            'Access-Control-Allow-Origin': '*',
+        },
         'isBase64Encoded': False,
         'statusCode': 200,
         'body': json.dumps(result),

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="rpkilog.css">
     <script>
         var rpkilog_config = {
-            "api_url": "https://lv67q6w52abgu2igfbpef5vhsm0jahqq.lambda-url.us-east-1.on.aws/"
+            "api_url": "https://api.rpkilog.com/unstable/history"
         };
     </script>
     <script src="main.js" type="module"></script>


### PR DESCRIPTION
Changed from using AWS Lambda Function URL to using a REST API Gateway https://api.rpkilog.com to provide a permanent URL in case anyone would like to consume it.

The old Function URL is still online for the moment.  It can be cleaned up from Terraform later.