### PR TITLE
fix v6 prefix length check

### DIFF
--- a/www/rpkilog.js
+++ b/www/rpkilog.js
@@ -24,7 +24,7 @@ export class VrpEntry {
             }
         } else if (prefix.match(/^([0-9A-Fa-f:]+:.+)\/(\d{1,3})$/)) {
             this.family = 6
-            if (! this.maxLength >= 0 && this.maxLength <= 128) {
+            if (!(0 <= this.maxLength && this.maxLength <= 128)) {
                 throw new TypeError('maxLength must be an integer from 0 to 128 for IPv6 prefixes');
             }
         } else {


### PR DESCRIPTION
it was failing on all v6 prefixes as `!this.maxLength`

before
![before](https://github.com/user-attachments/assets/b4de5ce9-4cdb-4b73-8719-91760f7be3f8)


after
![after](https://github.com/user-attachments/assets/214f4b29-383e-4d2f-aecb-563846de9a21)
