### PR TITLE
GH-29: local validators

### DIFF
--- a/python/rpkilog/pyproject.toml
+++ b/python/rpkilog/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'rpkilog'
-version = '0.26050301'
+version = '0.26050701'
 authors = [{ name = 'Jeff Wheeler', email = 'jeffsw6@gmail.com' }]
 dependencies = [
     'boto3',

--- a/python/rpkilog/pyproject.toml
+++ b/python/rpkilog/pyproject.toml
@@ -56,6 +56,7 @@ rpkilog-diff-import = 'rpkilog:VrpDiff.cli_entry_point_import'
 rpkilog-hapi = 'rpkilog.hapi:cli_entry_point'
 rpkilog-ingest-tar = 'rpkilog:IngestTar.cli_entry_point'
 rpkilog-routinator-vrp-fetcher = 'rpkilog.routinator_vrp_fetcher:cli_entry_point'
+rpkilog-rpkiclient-uploader = 'rpkilog.rpkiclient_uploader:cli_entry_point'
 rpkilog-vrp-cache-differ = 'rpkilog:VrpDiff.cli_entry_point'
 
 [tool.black]

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -50,7 +50,7 @@ def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
     logger.info(f'Preparing to upload {len(json_buffer)/1048576:.1f} MB by compressing to {bz2_filename}')
     bz2_buffer = bz2.compress(json_buffer)
     bucket = boto3.resource('s3').Bucket(s3_bucket_name)
-    logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576:1.f} MB'
+    logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576:.1f} MB'
                 f' compressed: {len(bz2_buffer)/1048576:.1f} MB')
     s3_object = bucket.put_object(Key=bz2_filename, Body=bz2_buffer)
     logger.info(f'Uploaded successfully: {s3_object}')

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -49,7 +49,10 @@ def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
         return None
     bz2_buffer = bz2.compress(json_buffer)
     bucket = boto3.resource('s3').Bucket(s3_bucket_name)
+    logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576} MB'
+                f' compressed: {len(bz2_buffer)/1048576} MB')
     s3_object = bucket.put_object(key=bz2_filename, Body=bz2_buffer)
+    logger.info(f'Uploaded successfully: {s3_object}')
     return s3_object.key
 
 
@@ -62,4 +65,12 @@ def cli_entry_point():
     ap.add_argument(
         '--s3-snapshot-summary-bucket', required=True, type=str,
         help='Name of the rpkiclient snapshot-summary bucket'
+    )
+    ap.add_argument('--debug', action='store_true', help='Break to debugger on start-up')
+    args = ap.parse_args()
+    if args.debug:
+        breakpoint()
+    s3_upload(
+        rpkiclient_json=args.json_file_path,
+        s3_bucket_name=args.s3_snapshot_summary_bucket,
     )

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -58,6 +58,7 @@ def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
 
 
 def cli_entry_point():
+    logging.basicConfig(level='INFO')
     ap = argparse.ArgumentParser()
     ap.add_argument(
         '--json-file-path', required=True, type=Path,

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -51,7 +51,7 @@ def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
     bz2_buffer = bz2.compress(json_buffer)
     bucket = boto3.resource('s3').Bucket(s3_bucket_name)
     logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576:1.f} MB'
-                f' compressed: {len(bz2_buffer)/1048576:1.f} MB')
+                f' compressed: {len(bz2_buffer)/1048576:.1f} MB')
     s3_object = bucket.put_object(Key=bz2_filename, Body=bz2_buffer)
     logger.info(f'Uploaded successfully: {s3_object}')
     return s3_object.key

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -1,0 +1,63 @@
+"""
+This is being written in a bit of a rush to start sourcing snapshots from our own validator.
+There is opportunity for re-use being ignored here.
+"""
+import argparse
+import bz2
+from datetime import datetime, timezone, UTC
+import json
+import logging
+import os
+from pathlib import Path
+
+import boto3
+import dateutil.parser
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_bz2_filename_from_datetime(dt: datetime) -> str:
+    retval = dt.strftime('%Y%m%dT%H%M%SZ.json.bz2')
+    return retval
+
+
+def get_rpkiclient_datetime_from_json(json_serialized: bytes | str) -> datetime:
+    json_data = json.loads(json_serialized)
+    retval = dateutil.parser.parse(json_data['metadata']['buildtime'])
+    return retval
+
+
+def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
+    """
+    Given a Path to rpkiclient's output/json file, determine if it is already present in the given S3 bucket.
+    If not, bzip2 and upload it.  Filename format is YYYYMMDDTHHMMSSZ.json.bz2.
+    """
+    with open(rpkiclient_json, 'rb') as json_fh:
+        json_buffer = json_fh.read()
+    json_datetime = get_rpkiclient_datetime_from_json(json_serialized=json_buffer)
+    bz2_filename = get_bz2_filename_from_datetime(json_datetime)
+    s3 = boto3.client('s3')
+    s3_list_result = s3.list_objects(
+        Bucket = s3_bucket_name,
+        Prefix = bz2_filename,
+    )
+    if len(s3_list_result.get('Contents', [])):
+        # the currently-available rpkiclient json file has already been uploaded
+        return None
+    bz2_buffer = bz2.compress(json_buffer)
+    bucket = boto3.resource('s3').Bucket(s3_bucket_name)
+    s3_object = bucket.put_object(key=bz2_filename, Body=bz2_buffer)
+    return s3_object.key
+
+
+def cli_entry_point():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        '--json-file-path', required=True, type=Path,
+        help='Path to rpkiclient summary JSON file'
+    )
+    ap.add_argument(
+        '--s3-snapshot-summary-bucket', required=True, type=str,
+        help='Name of the rpkiclient snapshot-summary bucket'
+    )

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -7,7 +7,6 @@ import bz2
 from datetime import datetime, timezone, UTC
 import json
 import logging
-import os
 from pathlib import Path
 
 import boto3
@@ -15,6 +14,7 @@ import dateutil.parser
 
 
 logger = logging.getLogger(__name__)
+MINIMUM_JSON_SIZE = 8_500_000
 
 
 def get_bz2_filename_from_datetime(dt: datetime) -> str:
@@ -35,6 +35,8 @@ def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
     """
     with open(rpkiclient_json, 'rb') as json_fh:
         json_buffer = json_fh.read()
+    if len(json_buffer) < MINIMUM_JSON_SIZE:
+        raise RuntimeError(f'JSON file is too small to be reliable: {rpkiclient_json} < {MINIMUM_JSON_SIZE}')
     json_datetime = get_rpkiclient_datetime_from_json(json_serialized=json_buffer)
     bz2_filename = get_bz2_filename_from_datetime(json_datetime)
     s3 = boto3.client('s3')

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -45,13 +45,14 @@ def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
         Prefix = bz2_filename,
     )
     if len(s3_list_result.get('Contents', [])):
-        # the currently-available rpkiclient json file has already been uploaded
+        logger.info(f'Currently available rpkiclient json file {json_datetime} has already been uploaded.')
         return None
+    logger.info(f'Preparing to upload {len(json_buffer)/1048576:.1f} MB by compressing to {bz2_filename}')
     bz2_buffer = bz2.compress(json_buffer)
     bucket = boto3.resource('s3').Bucket(s3_bucket_name)
-    logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576} MB'
-                f' compressed: {len(bz2_buffer)/1048576} MB')
-    s3_object = bucket.put_object(key=bz2_filename, Body=bz2_buffer)
+    logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576:1.f} MB'
+                f' compressed: {len(bz2_buffer)/1048576:1.f} MB')
+    s3_object = bucket.put_object(Key=bz2_filename, Body=bz2_buffer)
     logger.info(f'Uploaded successfully: {s3_object}')
     return s3_object.key
 

--- a/scripts/aws_key_manager.py
+++ b/scripts/aws_key_manager.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+"""
+Rotate IAM access keys for a given user and write the new credentials to a file.
+
+Intended to be invoked by the system Python from cloud-init.
+"""
+
+import argparse
+import logging
+import os
+import shutil
+import socket
+
+import boto3
+
+LOG = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Rotate IAM access keys for an IAM user and write credentials to a file."
+    )
+    parser.add_argument("--username", required=True, help="IAM username whose access keys will be rotated")
+    parser.add_argument("--cred-file-path", required=True, help="Path to the AWS credentials file to write")
+    parser.add_argument("--cred-file-owner", required=True, help="Unix username to own the credentials file")
+    parser.add_argument("--cred-file-group", default=None, help="Unix group to own the credentials file")
+    parser.add_argument("--debug", action="store_true", help="Break to debugger upon start-up")
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    args = parse_args()
+
+    if args.debug:
+        breakpoint()
+
+    iam = boto3.client("iam")
+
+    # 1. Delete any existing access keys, logging metadata first.
+    existing_keys = iam.list_access_keys(UserName=args.username)["AccessKeyMetadata"]
+    for key in existing_keys:
+        last_used_resp = iam.get_access_key_last_used(AccessKeyId=key["AccessKeyId"])
+        last_used = last_used_resp.get("AccessKeyLastUsed", {}).get("LastUsedDate", "never")
+        LOG.info(
+            "Deleting existing access key: KeyId=%s Status=%s CreateDate=%s LastUsed=%s",
+            key["AccessKeyId"],
+            key["Status"],
+            key["CreateDate"],
+            last_used,
+        )
+        iam.delete_access_key(UserName=args.username, AccessKeyId=key["AccessKeyId"])
+
+    # 2. Create a new access key.
+    hostname = socket.gethostname()
+    description = f"created by aws_key_manager.py from {hostname}"
+    new_key = iam.create_access_key(UserName=args.username)["AccessKey"]
+    LOG.info("Created new access key: KeyId=%s (%s)", new_key["AccessKeyId"], description)
+
+    # 3. Write credentials file in AWS INI format.
+    cred_content = (
+        "[default]\n"
+        f"aws_access_key_id = {new_key['AccessKeyId']}\n"
+        f"aws_secret_access_key = {new_key['SecretAccessKey']}\n"
+    )
+
+    cred_path = args.cred_file_path
+    with open(os.open(cred_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600), "w") as f:
+        f.write(cred_content)
+
+    shutil.chown(cred_path, user=args.cred_file_owner, group=args.cred_file_group)
+
+    LOG.info("Credentials written to %s (owner=%s)", cred_path, args.cred_file_owner)
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/root/dev/.terraform.lock.hcl
+++ b/terraform/root/dev/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.44.0"
+  hashes = [
+    "h1:NYUMqeKfML2PtEyC5Ob/g44PkxIzoKBsNSftrZvRY24=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}
+
 provider "registry.terraform.io/lxc/incus" {
   version     = "1.0.2"
   constraints = "~> 1.0.2"

--- a/terraform/root/dev/.terraform.lock.hcl
+++ b/terraform/root/dev/.terraform.lock.hcl
@@ -24,6 +24,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.8.1"
+  hashes = [
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}
+
 provider "registry.terraform.io/lxc/incus" {
   version     = "1.0.2"
   constraints = "~> 1.0.2"

--- a/terraform/root/dev/.terraform.lock.hcl
+++ b/terraform/root/dev/.terraform.lock.hcl
@@ -24,6 +24,25 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.5"
+  hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.8.1"
   constraints = "~> 3.8.1"

--- a/terraform/root/dev/_rpkilog_dev.tf
+++ b/terraform/root/dev/_rpkilog_dev.tf
@@ -1,5 +1,12 @@
 terraform {
   required_version = "~> 1.14.0"
+  backend "s3" {
+    bucket = "rpkilog-terraform"
+    region = "us-east-1"
+    workspace_key_prefix = "new"
+    key = "terraform.tfstate"
+    use_lockfile = true
+  }
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/root/dev/_rpkilog_dev.tf
+++ b/terraform/root/dev/_rpkilog_dev.tf
@@ -38,6 +38,8 @@ provider "incus" {
 
 provider "random" {}
 
+data "aws_caller_identity" "main" {}
+
 data "aws_s3_bucket" "snapshot_summary" {
   bucket = var.snapshot_bucket_name
 }
@@ -74,11 +76,21 @@ resource "random_password" "rpkiclient_2" {
   upper = true
 }
 
+data "external" "rpkiclient_key_manager_aws_sts_token" {
+  program = [
+    "bash", "-c",
+    "aws sts assume-role --role-arn ${aws_iam_role.vm_rpkiclient_key_manager.arn} --role-session-name terraform-rpkiclient-key-manager --duration-seconds 1200 | jq '.Credentials'"
+  ]
+  depends_on = [aws_iam_role.vm_rpkiclient_key_manager]
+}
+
 locals {
   user_data_rpkiclient_2 = {
-    aws_access_key_id: aws_iam_access_key.rpkiclient_uploader.id
-    aws_secret_access_key: nonsensitive(aws_iam_access_key.rpkiclient_uploader.secret)
     console_random_password_plaintext = nonsensitive(random_password.rpkiclient_2.result)
+    key_manager_aws_access_key_id: data.external.rpkiclient_key_manager_aws_sts_token.result["AccessKeyId"]
+    key_manager_aws_secret_access_key: data.external.rpkiclient_key_manager_aws_sts_token.result["SecretAccessKey"]
+    key_manager_aws_session_token: data.external.rpkiclient_key_manager_aws_sts_token.result["SessionToken"]
+    uploader_iam_username = aws_iam_user.rpkiclient_uploader.name
     path: {
       module: path.module
     }

--- a/terraform/root/dev/_rpkilog_dev.tf
+++ b/terraform/root/dev/_rpkilog_dev.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "~> 1.14.0"
   required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 6.44.0"
+    }
     incus = {
       source  = "lxc/incus"
       version = "~> 1.0.2"
@@ -8,11 +12,28 @@ terraform {
   }
 }
 
+provider "aws" {
+  allowed_account_ids = [
+    "054500078560",  # rpkilog
+  ]
+  default_tags {
+    tags = {
+      tf_managed = "rpkilog/terraform/root/dev"
+      workspace  = terraform.workspace
+    }
+  }
+  region = "us-east-1"
+}
+
 provider "incus" {
   default_remote = "router26a"
   remote {
     name = "router26a"
   }
+}
+
+data "aws_s3_bucket" "snapshot_summary" {
+  bucket = var.snapshot_bucket_name
 }
 
 data "incus_storage_pool" "default" {

--- a/terraform/root/dev/_rpkilog_dev.tf
+++ b/terraform/root/dev/_rpkilog_dev.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "lxc/incus"
       version = "~> 1.0.2"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.8.1"
+    }
   }
 }
 
@@ -31,6 +35,8 @@ provider "incus" {
     name = "router26a"
   }
 }
+
+provider "random" {}
 
 data "aws_s3_bucket" "snapshot_summary" {
   bucket = var.snapshot_bucket_name
@@ -60,6 +66,26 @@ resource "incus_storage_volume" "routinator_1_volume_1" {
   }
 }
 
+resource "random_password" "rpkiclient_2" {
+  length = 14
+  lower  = true
+  numeric = true
+  special = false
+  upper = true
+}
+
+locals {
+  user_data_rpkiclient_2 = {
+    aws_access_key_id: aws_iam_access_key.rpkiclient_uploader.id
+    aws_secret_access_key: nonsensitive(aws_iam_access_key.rpkiclient_uploader.secret)
+    console_random_password_plaintext = nonsensitive(random_password.rpkiclient_2.result)
+    path: {
+      module: path.module
+    }
+    script_install_rpkilog: file("${path.module}/install_rpkilog.sh")
+  }
+}
+
 # https://registry.terraform.io/providers/lxc/incus/latest/docs/resources/instance
 resource "incus_instance" "rpkiclient_2" {
   name  = "rpkiclient-2"
@@ -72,7 +98,7 @@ resource "incus_instance" "rpkiclient_2" {
     "limits.cpu"           = "10,11"
     # would run fine with 2GB RAM
     "limits.memory"  = "8GB"
-    "user.user-data" = file("${path.module}/rpkiclient-2.yml")
+    "user.user-data" = templatefile("${path.module}/rpkiclient-2.yml.tftpl", local.user_data_rpkiclient_2)
   }
   device {
     name = "volume1"
@@ -96,6 +122,7 @@ resource "incus_instance" "routinator_1" {
     "limits.cpu"           = "8,9"
     # would run fine with 2GB RAM
     "limits.memory"  = "8GB"
+    # TODO: replace with templatefile() to pass in configuration and AWS API key
     "user.user-data" = file("${path.module}/routinator-1.yml")
   }
   # appears as /dev/sdb and cloud-init will partition & create /data filesystem

--- a/terraform/root/dev/iam_snapshot_upload.tf
+++ b/terraform/root/dev/iam_snapshot_upload.tf
@@ -1,14 +1,58 @@
-# ⚠️ This user will be created with no API keys or password.  It's necessary to MANUALLY create an API
-# secret-key, then re-invoke this Terraform workspace with var.rpkiclient_uploader_iam_secret_key, to
-# complete provisioning of all resources.  Prior to that, the default value will allow provisioning the
-# VMs & software setup.
-#
-# 🚀 To fix this, we should use a local exec provisioner to create an ephemeral GPG key, then use that
-# key and the Terraform IAM user api key GPG feature to get an encrypted key, and pass both the GPG key
-# and encrypted API key to the rpkiclient instance.
-# The main question about this approach is how to avoid replacing the key every time Terraform runs.
-# Make sure neither key ends up in state or git.
-# This will also require templating the cloud-init user-data so the key(s) can get to it.
+# At VM creation time we pass a temporary 20-minute STS token to the VM via user-data.
+# That token uses the rpkiclient_key_manager_{dev} to rotate API keys on the *other* user managed in
+# this file, vm_rpkiclient_key_manager_{dev}.
+# The result is, although rpkiclient_key_manager's token is stored in the Terraform state, it's only
+# valid for 20 minutes.
+resource "aws_iam_policy" "rpkiclient_key_manager" {
+  name = "rpkiclient_key_manager_${terraform.workspace}"
+  policy = jsonencode({
+    Version: "2012-10-17"
+    Statement: [
+      {
+        Sid: "ManageAccessKeysForRpkiclientUploaderDev",
+        Effect: "Allow",
+        Action: [
+          "iam:CreateAccessKey",
+          "iam:DeleteAccessKey",
+          "iam:ListAccessKeys",
+          "iam:UpdateAccessKey",
+          "iam:GetAccessKeyLastUsed"
+        ],
+        Resource: "arn:aws:iam::${data.aws_caller_identity.main.account_id}:user/rpkiclient_uploader_dev"
+      },
+      {
+        Sid: "GetUserInfo",
+        Effect: "Allow",
+        Action: [
+          "iam:GetUser"
+        ],
+        Resource: "arn:aws:iam::${data.aws_caller_identity.main.account_id}:user/rpkiclient_uploader_dev"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "vm_rpkiclient_key_manager" {
+  name = "vm_rpkiclient_key_manager_${terraform.workspace}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.main.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "vm_rpkiclient_key_manager" {
+  role_name   = aws_iam_role.vm_rpkiclient_key_manager.name
+  policy_arns = [aws_iam_policy.rpkiclient_key_manager.arn]
+}
+
 resource "aws_iam_user" "rpkiclient_uploader" {
   name = "rpkiclient_uploader_${terraform.workspace}"
 }

--- a/terraform/root/dev/iam_snapshot_upload.tf
+++ b/terraform/root/dev/iam_snapshot_upload.tf
@@ -2,6 +2,13 @@
 # secret-key, then re-invoke this Terraform workspace with var.rpkiclient_uploader_iam_secret_key, to
 # complete provisioning of all resources.  Prior to that, the default value will allow provisioning the
 # VMs & software setup.
+#
+# 🚀 To fix this, we should use a local exec provisioner to create an ephemeral GPG key, then use that
+# key and the Terraform IAM user api key GPG feature to get an encrypted key, and pass both the GPG key
+# and encrypted API key to the rpkiclient instance.
+# The main question about this approach is how to avoid replacing the key every time Terraform runs.
+# Make sure neither key ends up in state or git.
+# This will also require templating the cloud-init user-data so the key(s) can get to it.
 resource "aws_iam_user" "rpkiclient_uploader" {
   name = "rpkiclient_uploader_${terraform.workspace}"
 }
@@ -32,4 +39,8 @@ resource "aws_iam_policy" "rpkiclient_uploader" {
 resource "aws_iam_user_policy_attachment" "rpkiclient_uploader" {
   user = aws_iam_user.rpkiclient_uploader.name
   policy_arn = aws_iam_policy.rpkiclient_uploader.arn
+}
+
+resource "aws_iam_access_key" "rpkiclient_uploader" {
+  user = aws_iam_user.rpkiclient_uploader.name
 }

--- a/terraform/root/dev/iam_snapshot_upload.tf
+++ b/terraform/root/dev/iam_snapshot_upload.tf
@@ -1,0 +1,35 @@
+# ⚠️ This user will be created with no API keys or password.  It's necessary to MANUALLY create an API
+# secret-key, then re-invoke this Terraform workspace with var.rpkiclient_uploader_iam_secret_key, to
+# complete provisioning of all resources.  Prior to that, the default value will allow provisioning the
+# VMs & software setup.
+resource "aws_iam_user" "rpkiclient_uploader" {
+  name = "rpkiclient_uploader_${terraform.workspace}"
+}
+
+resource "aws_iam_policy" "rpkiclient_uploader" {
+  name = "rpkiclient_uploader_${terraform.workspace}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:PutObjectRetention",
+          "s3:PutObjectTagging",
+        ],
+        Resource = [
+          data.aws_s3_bucket.snapshot_summary.arn,
+          "${data.aws_s3_bucket.snapshot_summary.arn}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "rpkiclient_uploader" {
+  user = aws_iam_user.rpkiclient_uploader.name
+  policy_arn = aws_iam_policy.rpkiclient_uploader.arn
+}

--- a/terraform/root/dev/install_rpkilog.sh
+++ b/terraform/root/dev/install_rpkilog.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+#
+# common script likely to be copied to /var/lib/cloud/scripts/per-once/100-rpki-client.sh
+# or otherwise run once upon a new VM's first boot
+#
+ARCH=$(uname --machine)
+INSTALL_BRANCH=GH-29-local-validators
+VENV_DIR=/opt/rpkilog/venv/
+
+##############################
+# Python
+mkdir -p ${VENV_DIR}
+python3 -m venv ${VENV_DIR}
+${VENV_DIR}/bin/pip install \
+  botocore \
+  boto3 \
+  bcdoc \
+  ipython \
+
+##############################
+# AWS CLI
+pushd /usr/local/src
+if [[ ${ARCH} = "x86_64" ]]; then
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+elif [[ ${ARCH} = "aarch64" ]]; then
+curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+else
+echo "Expecting uname --machine output to be x86_64 or aarch64 but it is ${ARCH}"
+exit 1
+fi
+unzip awscliv2.zip
+./aws/install
+popd
+
+##############################
+# rpkilog python from github
+${VENV_DIR}/bin/pip3 install "git+https://github.com/jeffsw/rpkilog.git@${INSTALL_BRANCH}#subdirectory=python/rpkilog"

--- a/terraform/root/dev/rpkiclient-2.yml
+++ b/terraform/root/dev/rpkiclient-2.yml
@@ -34,6 +34,11 @@ packages:
   - htop
   - incus-agent
   - openssh-server
+  - python3-bcdoc \
+  - python3-boto3 \
+  - python3-botocore \
+  - python3-full \
+  - python3-pip \
   - run-one
   - ssh-import-id
   - bzip2

--- a/terraform/root/dev/rpkiclient-2.yml
+++ b/terraform/root/dev/rpkiclient-2.yml
@@ -34,7 +34,9 @@ packages:
   - htop
   - incus-agent
   - openssh-server
+  - run-one
   - ssh-import-id
+  - bzip2
 users:
   - name: jsw
     groups: adm,docker,sudo
@@ -42,12 +44,17 @@ users:
     sudo: "ALL=(ALL) NOPASSWD: ALL"
     ssh_authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4k8nVaS9Ns+8jZ1C97eUcOvkFw6NOXS8e4xxG6XEH1l9PDluOCxAqgCvdKxX9ZhFvwW1SCSWuN95WrM7u/9p0flOX7DZFYld053ClWxMZZ4ZtKj8XWnmDU4LLXSmUWaKddW9pHZHvxfEFu+wCcnUiJM4NgS4owfaIGC3IOIXVrxsoNuoKyTQS9pRa5+3sMC3rHK8oWPkleJGO+cs8AxuetRtHS/ZHwshsyI27ROC/nIxZ7ZeKXf3g/jxEpbxI9LNFnocuUmeoNpndBFYND1ujwiHZvoWxx4ByiTRDNJDHJWdnJpz8rOmnoHeHFqV8F/I5CRG9Dh7aq5vd9LWdrkqb jeffsw6@gmail.com boomer 2013-05-28
+  - name: rpkilog
+    shell: /usr/bin/bash
 write_files:
   - path: /var/lib/cloud/scripts/per-once/100-rpki-client.sh
     permissions: "0755"
-    content: |
-        #!/bin/bash
+    content: |4
+        #!/bin/bash -e
 
+        ARCH=$(uname --machine)      
+        VENV_DIR=/opt/rpkilog/venv/
+      
         # rpki-client container from https://hub.docker.com/r/rpki/rpki-client
         docker run --name rpkiclient \
           --restart unless-stopped \
@@ -56,3 +63,44 @@ write_files:
           --publish 9099:9099/tcp \
           --detach \
           rpki/rpki-client:latest
+      
+        ##############################
+        # Python
+
+        mkdir -p ${VENV_DIR}
+        python3 -m venv ${VENV_DIR}
+        ${VENV_DIR}/bin/pip install \
+          botocore \
+          boto3 \
+          bcdoc \
+          ipython \
+
+        ##############################
+        # AWS CLI
+        pushd /usr/local/src
+        if [[ ${ARCH} = "x86_64" ]]; then
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        elif [[ ${ARCH} = "aarch64" ]]; then
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+        else
+        echo "Expecting uname --machine output to be x86_64 or aarch64 but it is ${ARCH}"
+        exit 1
+        fi
+        unzip awscliv2.zip
+        ./aws/install
+        popd
+
+        ##############################
+        # rpkilog python from github
+        ${VENV_DIR}/bin/pip3 install "git+https://github.com/jeffsw/rpkilog.git#subdirectory=python/rpkilog"
+      
+        ##############################
+        # TODO: rpki summary uploader
+        # for rpki-client it should watch the json file for a new timestamp and upload when available
+        # for routinator it should be on a schedule (I think) so a one-shot invocation from cron would be fine
+  - path: /etc/cron.d/rpkiclient_uploader
+    content: |4
+        */5 * * * * rpkilog run-one rpkilog-rpkiclient-uploader \
+        --json-file-path /data/rpkiclient/output/json \
+        --s3-snapshot-summary-bucket rpkilog-snapshot-summary \
+        2>&1 | logger -t rpkiclient_uploader

--- a/terraform/root/dev/rpkiclient-2.yml.tftpl
+++ b/terraform/root/dev/rpkiclient-2.yml.tftpl
@@ -59,6 +59,24 @@ users:
   - name: rpkilog
     shell: /usr/bin/bash
 write_files:
+  - path: /root/.aws/config
+    owner: root:root
+    permissions: '0600'
+    content: |4
+        [default]
+        region = us-east-1
+  - path: /root/.aws/credentials
+    owner: root:root
+    permissions: '0600'
+    content: |4
+        [default]
+        aws_access_key_id = ${key_manager_aws_access_key_id}
+        aws_secret_access_key = ${key_manager_aws_secret_access_key}
+        aws_session_token = ${key_manager_aws_session_token}
+  - path: /usr/local/bin/100_aws_key_manager.py
+    permissions: "0755"
+    content: |4
+        ${indent(8, file("${path.module}/../../../scripts/aws_key_manager.py"))}
   - path: /var/lib/cloud/scripts/per-once/100_install_rpkilog.sh
     permissions: "0755"
     content: |4
@@ -88,11 +106,13 @@ write_files:
     content: |4
         [default]
         region = us-east-1
-  - path: /home/rpkilog/.aws/credentials
+  - path: /var/lib/cloud/scripts/per-once/100_aws_key_manager_wrapper.sh
     defer: true
-    owner: rpkilog:rpkilog
-    permissions: '0600'
+    permissions: "0755"
     content: |4
-        [default]
-        aws_access_key_id = ${aws_access_key_id}
-        aws_secret_access_key = ${aws_secret_access_key}
+        #!/bin/bash -e
+        /usr/local/bin/100_aws_key_manager.py \
+          --username ${uploader_iam_username} \
+          --cred-file-path /home/rpkilog/.aws/credentials \
+          --cred-file-owner rpkilog \
+          --cred-file-group rpkilog

--- a/terraform/root/dev/rpkiclient-2.yml.tftpl
+++ b/terraform/root/dev/rpkiclient-2.yml.tftpl
@@ -27,6 +27,7 @@ package_reboot_if_required: true
 package_update: true
 package_upgrade: true
 packages:
+  - bzip2
   - ca-certificates
   - curl
   - docker-ce
@@ -34,17 +35,23 @@ packages:
   - htop
   - incus-agent
   - openssh-server
-  - python3-bcdoc \
-  - python3-boto3 \
-  - python3-botocore \
-  - python3-full \
-  - python3-pip \
+  - python3-bcdoc
+  - python3-boto3
+  - python3-botocore
+  - python3-full
+  - python3-pip
+  - python3-venv
   - run-one
   - ssh-import-id
-  - bzip2
+  - unzip
+runcmd:
+  # ensure /home/rpkilog/.aws and other directories we may be creating with cloud-init have correct ownership
+  - "chown -R rpkilog:rpkilog /home/rpkilog"
 users:
   - name: jsw
     groups: adm,docker,sudo
+    lock_passwd: false
+    plain_text_passwd: "${console_random_password_plaintext}"
     shell: /usr/bin/bash
     sudo: "ALL=(ALL) NOPASSWD: ALL"
     ssh_authorized_keys:
@@ -52,14 +59,14 @@ users:
   - name: rpkilog
     shell: /usr/bin/bash
 write_files:
-  - path: /var/lib/cloud/scripts/per-once/100-rpki-client.sh
+  - path: /var/lib/cloud/scripts/per-once/100_install_rpkilog.sh
+    permissions: "0755"
+    content: |4
+        ${indent(8, file("${path.module}/install_rpkilog.sh"))}
+  - path: /var/lib/cloud/scripts/per-once/100_docker_run_rpkiclient.sh
     permissions: "0755"
     content: |4
         #!/bin/bash -e
-
-        ARCH=$(uname --machine)      
-        VENV_DIR=/opt/rpkilog/venv/
-      
         # rpki-client container from https://hub.docker.com/r/rpki/rpki-client
         docker run --name rpkiclient \
           --restart unless-stopped \
@@ -68,44 +75,24 @@ write_files:
           --publish 9099:9099/tcp \
           --detach \
           rpki/rpki-client:latest
-      
-        ##############################
-        # Python
-
-        mkdir -p ${VENV_DIR}
-        python3 -m venv ${VENV_DIR}
-        ${VENV_DIR}/bin/pip install \
-          botocore \
-          boto3 \
-          bcdoc \
-          ipython \
-
-        ##############################
-        # AWS CLI
-        pushd /usr/local/src
-        if [[ ${ARCH} = "x86_64" ]]; then
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        elif [[ ${ARCH} = "aarch64" ]]; then
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
-        else
-        echo "Expecting uname --machine output to be x86_64 or aarch64 but it is ${ARCH}"
-        exit 1
-        fi
-        unzip awscliv2.zip
-        ./aws/install
-        popd
-
-        ##############################
-        # rpkilog python from github
-        ${VENV_DIR}/bin/pip3 install "git+https://github.com/jeffsw/rpkilog.git#subdirectory=python/rpkilog"
-      
-        ##############################
-        # TODO: rpki summary uploader
-        # for rpki-client it should watch the json file for a new timestamp and upload when available
-        # for routinator it should be on a schedule (I think) so a one-shot invocation from cron would be fine
   - path: /etc/cron.d/rpkiclient_uploader
-    content: |4
-        */5 * * * * rpkilog run-one rpkilog-rpkiclient-uploader \
-        --json-file-path /data/rpkiclient/output/json \
-        --s3-snapshot-summary-bucket rpkilog-snapshot-summary \
+    content: >4
+        */5 * * * * rpkilog run-one /opt/rpkilog/venv/bin/rpkilog-rpkiclient-uploader
+        --json-file-path /data/rpkiclient/output/json
+        --s3-snapshot-summary-bucket rpkilog-snapshot-summary
         2>&1 | logger -t rpkiclient_uploader
+  - path: /home/rpkilog/.aws/config
+    defer: true
+    owner: rpkilog:rpkilog
+    permissions: '0600'
+    content: |4
+        [default]
+        region = us-east-1
+  - path: /home/rpkilog/.aws/credentials
+    defer: true
+    owner: rpkilog:rpkilog
+    permissions: '0600'
+    content: |4
+        [default]
+        aws_access_key_id = ${aws_access_key_id}
+        aws_secret_access_key = ${aws_secret_access_key}

--- a/terraform/root/dev/rpkiclient-2.yml.tftpl
+++ b/terraform/root/dev/rpkiclient-2.yml.tftpl
@@ -47,6 +47,7 @@ packages:
 runcmd:
   # ensure /home/rpkilog/.aws and other directories we may be creating with cloud-init have correct ownership
   - "chown -R rpkilog:rpkilog /home/rpkilog"
+ssh_pwauth: false
 users:
   - name: jsw
     groups: adm,docker,sudo

--- a/terraform/root/dev/vars.tf
+++ b/terraform/root/dev/vars.tf
@@ -1,14 +1,3 @@
-# ⚠️ This user will be created with no API keys or password.  It's necessary to MANUALLY create an API
-# secret-key, then re-invoke this Terraform workspace with var.rpkiclient_uploader_iam_secret_key, to
-# complete provisioning of all resources.  Prior to that, the default value will allow provisioning the
-# VMs & software setup.
-variable "rpkiclient_uploader_iam_secret_key" {
-  description = "MANUALLY CREATED AWS IAM secret key for the rpkiclient_uploader_<workspace name> user"
-  type = string
-  ephemeral = true
-  default = "PLACEHOLDER_NOT_A_REAL_SECRET_KEY"
-}
-
 variable "snapshot_bucket_name" {
   type = string
   default = "rpkilog-snapshot-summary"

--- a/terraform/root/dev/vars.tf
+++ b/terraform/root/dev/vars.tf
@@ -1,0 +1,15 @@
+# ⚠️ This user will be created with no API keys or password.  It's necessary to MANUALLY create an API
+# secret-key, then re-invoke this Terraform workspace with var.rpkiclient_uploader_iam_secret_key, to
+# complete provisioning of all resources.  Prior to that, the default value will allow provisioning the
+# VMs & software setup.
+variable "rpkiclient_uploader_iam_secret_key" {
+  description = "MANUALLY CREATED AWS IAM secret key for the rpkiclient_uploader_<workspace name> user"
+  type = string
+  ephemeral = true
+  default = "PLACEHOLDER_NOT_A_REAL_SECRET_KEY"
+}
+
+variable "snapshot_bucket_name" {
+  type = string
+  default = "rpkilog-snapshot-summary"
+}


### PR DESCRIPTION
I've setup a local rpki-client VM for dev purposes, but temporary, switched to using that as the main data source as well (see discussion on GH-29).

As ever, this is messy, as it was done in a hurry and with no concern for code re-use.  My intention is to make some adjustments to the new `terraform/root/dev` compatible with slightly different runtime environments for dev vs prod and then migrate resources from the `/main.tf` as things need updating.

Additionally, in the Terraform state file, there are some plaintext AWS credentials related to the rpki-client VM, but these creds are only valid for 20 minutes and are used only to rotate an API key which is more persistent.  That persistent key doesn't end up in the state; only on the rpki-client VM where it's needed.  Both these keys have least-priv access.

One further thing, the rpki-client VM itself has a break glass password which is going into the state.  This is a bit of a trade-off also, but I plan to disable SSH password authentication from cloud-init w/ `ssh_pwauth: false` to mitigate this.  The password should only be needed for console access to troubleshoot.