### PR TITLE
GH-74: prepare rpkilog-diff-import-from-sqs for populating dev DB

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[env]
+# Activate the project venv so mise tasks can use Python and project CLI tools
+_.python.venv = "python/rpkilog/.venv"

--- a/.mise/tasks/replace-opensearch-1.rpkilog.dev.sh
+++ b/.mise/tasks/replace-opensearch-1.rpkilog.dev.sh
@@ -4,4 +4,5 @@
 set -euo pipefail
 terraform apply \
   -replace=module.opensearch_1_iam_user.shell_script.key_manager_sts_token \
+  -replace=random_string.opensearch_1_diff_import \
   -replace=incus_instance.opensearch_1

--- a/.mise/tasks/replace-opensearch-1.rpkilog.dev.sh
+++ b/.mise/tasks/replace-opensearch-1.rpkilog.dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Replace opensearch-1 VM and its STS token (dev)"
+#MISE dir="terraform/root/dev"
+set -euo pipefail
+terraform apply \
+  -replace=module.opensearch_1_iam_user.shell_script.key_manager_sts_token \
+  -replace=incus_instance.opensearch_1

--- a/.mise/tasks/replace-rpkiclient-2.rpkilog.dev.sh
+++ b/.mise/tasks/replace-rpkiclient-2.rpkilog.dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Replace rpkiclient-2 VM and its STS token (dev)"
+#MISE dir="terraform/root/dev"
+set -euo pipefail
+terraform apply \
+  -replace=module.rpkiclient_uploader.shell_script.key_manager_sts_token \
+  -replace=incus_instance.rpkiclient_2

--- a/python/rpkilog/pyproject.toml
+++ b/python/rpkilog/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'rpkilog'
-version = '0.26060201'
+version = '0.26060601'
 authors = [{ name = 'Jeff Wheeler', email = 'jeffsw6@gmail.com' }]
 dependencies = [
     "boto3",

--- a/python/rpkilog/rpkilog/vrp_diff.py
+++ b/python/rpkilog/rpkilog/vrp_diff.py
@@ -451,27 +451,37 @@ class VrpDiff():
     @classmethod
     def get_es_client(
         cls,
-        es_hostname: str,
+        es_endpoint: str,
         es_username: str = None,
         es_password: str = None,
+        es_ssl_verify: bool = True,
     ):
         """
         Create and return an OpenSearch client, verified with a ping.
 
-        es_hostname may include an optional port (e.g. 'localhost:9200' or 'es-prod.rpkilog.com').
-        Port defaults to 443.  SSL is enabled for port 443 and disabled otherwise.
+        es_endpoint must include a scheme (e.g. 'https://es-prod.rpkilog.com' or
+        'http://localhost:9200').  If no scheme is present, https:// is assumed and a
+        warning is logged — update the caller to supply an explicit scheme.
 
         Supply es_username/es_password for HTTP basic auth (dev OpenSearch).
         Omit both to use AWS IAM (AWS4Auth) — required for AWS-hosted OpenSearch.
         """
-        parsed = urllib.parse.urlsplit(f'//{es_hostname}')
+        if '://' not in es_endpoint:
+            logger.warning(
+                'es_endpoint %r has no scheme; assuming https://. Update the caller to supply an explicit scheme.',
+                es_endpoint,
+            )
+            es_endpoint = f'https://{es_endpoint}'
+        parsed = urllib.parse.urlsplit(es_endpoint)
         host = parsed.hostname
-        port = parsed.port or 443
-        use_ssl = (port == 443)
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+        use_ssl = (parsed.scheme == 'https')
 
         if es_username is not None:
+            auth_desc = f'basic auth user={es_username!r}'
             http_auth = (es_username, es_password)
         else:
+            auth_desc = 'AWS4Auth'
             aws_credentials = boto3.Session().get_credentials()
             try:
                 http_auth = AWS4Auth(
@@ -492,12 +502,14 @@ class VrpDiff():
             hosts=[{'host': host, 'port': port}],
             http_auth=http_auth,
             use_ssl=use_ssl,
-            verify_certs=use_ssl,
+            verify_certs=use_ssl and es_ssl_verify,
             connection_class=RequestsHttpConnection,
             http_compress=True,
         )
         if not es_client.ping():
-            raise ConnectionError(f'OpenSearch ping failed for {es_hostname}')
+            raise ConnectionError(
+                f'OpenSearch ping failed for {es_endpoint} (auth={auth_desc}, ssl_verify={es_ssl_verify})'
+            )
         return es_client
 
     @classmethod
@@ -879,11 +891,13 @@ class VrpDiff():
         ap.add_argument('--bulk-batch-size', type=int, default=200,
                         help='Number of records per OpenSearch _bulk operation (default: 200)')
         ap.add_argument('--es-endpoint',
-                        help='OpenSearch endpoint hostname (required unless --dry-run)')
+                        help='OpenSearch endpoint hostname e.g. https://localhost:9200 (required unless --dry-run)')
         ap.add_argument('--es-username',
                         help='OpenSearch username for HTTP basic auth (dev only)')
         ap.add_argument('--es-password',
                         help='OpenSearch password for HTTP basic auth (dev only)')
+        ap.add_argument('--es-ssl-verify', action=argparse.BooleanOptionalAction,
+                        help='Verify OpenSearch TLS certificate; also settable via ES_SSL_VERIFY env var')
         ap.add_argument('--max-message-count', type=int,
                         help='Stop after processing this many SQS messages')
         ap.add_argument('--dry-run', action='store_true', default=False,
@@ -907,6 +921,12 @@ class VrpDiff():
 
         es_username = args.get('es_username') or os.getenv('ES_USERNAME')
         es_password = args.get('es_password') or os.getenv('ES_PASSWORD')
+        if 'es_ssl_verify' in args:
+            es_ssl_verify = args['es_ssl_verify']
+        elif os.getenv('ES_SSL_VERIFY', 'true').lower() in ('false', '0', 'no'):
+            es_ssl_verify = False
+        else:
+            es_ssl_verify = True
 
         sqs = boto3.client('sqs')
         queue_url = sqs.get_queue_url(QueueName=args['sqs_name'])['QueueUrl']
@@ -929,6 +949,7 @@ class VrpDiff():
                     dry_run=args['dry_run'],
                     es_username=es_username,
                     es_password=es_password,
+                    es_ssl_verify=es_ssl_verify,
                 )
                 logger.info('Result for key %s: %s', key, json.dumps(result))
                 keys_imported += 1
@@ -1035,6 +1056,7 @@ class VrpDiff():
         dry_run: bool = False,
         es_username: str = None,
         es_password: str = None,
+        es_ssl_verify: bool = True,
     ):
         """
         Invoked by cli_entry_point_import or aws_lambda_entry_point_import
@@ -1060,9 +1082,10 @@ class VrpDiff():
         diff_datetime = dateutil.parser.parse(rem.group('datetime'))
         if not dry_run:
             es_client = cls.get_es_client(
-                es_hostname=es_endpoint,
+                es_endpoint=es_endpoint,
                 es_username=es_username,
                 es_password=es_password,
+                es_ssl_verify=es_ssl_verify,
             )
             es_index = cls.es_create_diff_index_for_datetime(index_datetime=diff_datetime, es_client=es_client)
         s3.download_file(Bucket=src_s3_bucket_name, Key=str(src_s3_key), Filename=str(diff_file_path))

--- a/python/rpkilog/rpkilog/vrp_diff.py
+++ b/python/rpkilog/rpkilog/vrp_diff.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import time
 import urllib.parse
+import urllib3
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -477,6 +478,9 @@ class VrpDiff():
         port = parsed.port or (443 if parsed.scheme == 'https' else 80)
         use_ssl = (parsed.scheme == 'https')
 
+        if not es_ssl_verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         if es_username is not None:
             auth_desc = f'basic auth user={es_username!r}'
             http_auth = (es_username, es_password)
@@ -939,7 +943,8 @@ class VrpDiff():
             if max_message_count is not None and messages_processed >= max_message_count:
                 break
             message_succeeded = True
-            for bucket, key, _record in s3_events_from_message(message):
+            notifications_processed = []
+            for bucket, key, record in s3_events_from_message(message):
                 logger.info('Importing key %s from bucket %s', key, bucket)
                 result = cls.generic_entry_point_import(
                     es_bulk_batch_size=args['bulk_batch_size'],
@@ -953,7 +958,19 @@ class VrpDiff():
                 )
                 logger.info('Result for key %s: %s', key, json.dumps(result))
                 keys_imported += 1
+                notifications_processed.append({
+                    'bucket': bucket,
+                    'key': key,
+                    's3RequestId': record.get('responseElements', {}).get('x-amz-request-id'),
+                })
             if not args['dry_run'] and message_succeeded:
+                logger.info(
+                    'Deleting SQS message: queue=%s messageId=%s notificationCount=%d notifications=%s',
+                    args['sqs_name'],
+                    message['MessageId'],
+                    len(notifications_processed),
+                    json.dumps(notifications_processed),
+                )
                 sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=message['ReceiptHandle'])
             messages_processed += 1
 

--- a/python/rpkilog/rpkilog/vrp_diff.py
+++ b/python/rpkilog/rpkilog/vrp_diff.py
@@ -861,8 +861,6 @@ class VrpDiff():
         )
         ap.add_argument('--sqs-name', required=True,
                         help='SQS queue name to consume (e.g. diff_dev)')
-        ap.add_argument('--bucket', required=True,
-                        help='S3 bucket containing diff files (e.g. rpkilog-diff)')
         ap.add_argument('--bulk-batch-size', type=int, default=200,
                         help='Number of records per OpenSearch _bulk operation (default: 200)')
         ap.add_argument('--es-endpoint',
@@ -899,12 +897,12 @@ class VrpDiff():
             if max_message_count is not None and messages_processed >= max_message_count:
                 break
             message_succeeded = True
-            for _bucket, key, _record in s3_events_from_message(message):
-                logger.info('Importing key %s from bucket %s', key, args['bucket'])
+            for bucket, key, _record in s3_events_from_message(message):
+                logger.info('Importing key %s from bucket %s', key, bucket)
                 result = cls.generic_entry_point_import(
                     es_bulk_batch_size=args['bulk_batch_size'],
                     es_endpoint=args['es_endpoint'],
-                    src_s3_bucket_name=args['bucket'],
+                    src_s3_bucket_name=bucket,
                     src_s3_key=key,
                     dry_run=args['dry_run'],
                 )

--- a/python/rpkilog/rpkilog/vrp_diff.py
+++ b/python/rpkilog/rpkilog/vrp_diff.py
@@ -13,6 +13,7 @@ import socket
 import sys
 import tempfile
 import time
+import urllib.parse
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -450,39 +451,53 @@ class VrpDiff():
     @classmethod
     def get_es_client(
         cls,
-        es_hostname:str,
-        es_port:int=443,
+        es_hostname: str,
+        es_username: str = None,
+        es_password: str = None,
     ):
-        '''
-        Move this to a utility module?
+        """
+        Create and return an OpenSearch client, verified with a ping.
 
-        FIXME: hard-coded AWS region
-        '''
-        aws_credentials = boto3.Session().get_credentials()
-        try:
-            aws_auth = AWS4Auth(
-                region='us-east-1',
-                service='es',
-                refreshable_credentials=aws_credentials
-            )
-        except:
-            aws_auth = AWS4Auth(
-                aws_credentials.access_key,
-                aws_credentials.secret_key,
-                'us-east-1',
-                'es',
-                aws_credentials.token,
-            )
+        es_hostname may include an optional port (e.g. 'localhost:9200' or 'es-prod.rpkilog.com').
+        Port defaults to 443.  SSL is enabled for port 443 and disabled otherwise.
+
+        Supply es_username/es_password for HTTP basic auth (dev OpenSearch).
+        Omit both to use AWS IAM (AWS4Auth) — required for AWS-hosted OpenSearch.
+        """
+        parsed = urllib.parse.urlsplit(f'//{es_hostname}')
+        host = parsed.hostname
+        port = parsed.port or 443
+        use_ssl = (port == 443)
+
+        if es_username is not None:
+            http_auth = (es_username, es_password)
+        else:
+            aws_credentials = boto3.Session().get_credentials()
+            try:
+                http_auth = AWS4Auth(
+                    region='us-east-1',
+                    service='es',
+                    refreshable_credentials=aws_credentials,
+                )
+            except TypeError:
+                http_auth = AWS4Auth(
+                    aws_credentials.access_key,
+                    aws_credentials.secret_key,
+                    'us-east-1',
+                    'es',
+                    aws_credentials.token,
+                )
+
         es_client = OpenSearch(
-            hosts = [
-                {'host': es_hostname, 'port': es_port},
-            ],
-            http_auth=aws_auth,
-            use_ssl=True,
-            verify_certs=True,
+            hosts=[{'host': host, 'port': port}],
+            http_auth=http_auth,
+            use_ssl=use_ssl,
+            verify_certs=use_ssl,
             connection_class=RequestsHttpConnection,
             http_compress=True,
         )
+        if not es_client.ping():
+            raise ConnectionError(f'OpenSearch ping failed for {es_hostname}')
         return es_client
 
     @classmethod
@@ -865,6 +880,10 @@ class VrpDiff():
                         help='Number of records per OpenSearch _bulk operation (default: 200)')
         ap.add_argument('--es-endpoint',
                         help='OpenSearch endpoint hostname (required unless --dry-run)')
+        ap.add_argument('--es-username',
+                        help='OpenSearch username for HTTP basic auth (dev only)')
+        ap.add_argument('--es-password',
+                        help='OpenSearch password for HTTP basic auth (dev only)')
         ap.add_argument('--max-message-count', type=int,
                         help='Stop after processing this many SQS messages')
         ap.add_argument('--dry-run', action='store_true', default=False,
@@ -886,6 +905,9 @@ class VrpDiff():
         if args['dry_run']:
             logger.info('Dry-run mode: SQS messages will not be deleted; OpenSearch will not be written')
 
+        es_username = args.get('es_username') or os.getenv('ES_USERNAME')
+        es_password = args.get('es_password') or os.getenv('ES_PASSWORD')
+
         sqs = boto3.client('sqs')
         queue_url = sqs.get_queue_url(QueueName=args['sqs_name'])['QueueUrl']
 
@@ -905,6 +927,8 @@ class VrpDiff():
                     src_s3_bucket_name=bucket,
                     src_s3_key=key,
                     dry_run=args['dry_run'],
+                    es_username=es_username,
+                    es_password=es_password,
                 )
                 logger.info('Result for key %s: %s', key, json.dumps(result))
                 keys_imported += 1
@@ -1003,12 +1027,14 @@ class VrpDiff():
     @classmethod
     def generic_entry_point_import(
         cls,
-        es_endpoint:str,
-        src_s3_bucket_name:str,
-        src_s3_key:str,
-        es_bulk_batch_size:int=200,
-        progress_bar_enable:bool=False,
-        dry_run:bool=False,
+        es_endpoint: str,
+        src_s3_bucket_name: str,
+        src_s3_key: str,
+        es_bulk_batch_size: int = 200,
+        progress_bar_enable: bool = False,
+        dry_run: bool = False,
+        es_username: str = None,
+        es_password: str = None,
     ):
         """
         Invoked by cli_entry_point_import or aws_lambda_entry_point_import
@@ -1033,7 +1059,11 @@ class VrpDiff():
         rem = re.match(r'^(?P<datetime>\d{8}T\d{6}Z)', diff_file_path.name)
         diff_datetime = dateutil.parser.parse(rem.group('datetime'))
         if not dry_run:
-            es_client = cls.get_es_client(es_hostname=es_endpoint)
+            es_client = cls.get_es_client(
+                es_hostname=es_endpoint,
+                es_username=es_username,
+                es_password=es_password,
+            )
             es_index = cls.es_create_diff_index_for_datetime(index_datetime=diff_datetime, es_client=es_client)
         s3.download_file(Bucket=src_s3_bucket_name, Key=str(src_s3_key), Filename=str(diff_file_path))
         if diff_file_path.suffix == '.bz2':

--- a/terraform/module/aws_iam_user_for_vm/.terraform.lock.hcl
+++ b/terraform/module/aws_iam_user_for_vm/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.44.0"
-  constraints = "~> 6.44.0"
+  constraints = "~> 6.0"
   hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
     "h1:NYUMqeKfML2PtEyC5Ob/g44PkxIzoKBsNSftrZvRY24=",
     "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
     "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
@@ -24,44 +25,24 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.4.0"
-  constraints = "~> 2.0"
+provider "registry.terraform.io/scottwinkler/shell" {
+  version     = "1.7.10"
+  constraints = "~> 1.7"
   hashes = [
-    "h1:vvIsrZAD5eNoNtXvNcBUxkA9k2A4JcC8JTDFbM9d8gc=",
-    "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
-    "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
-    "zh:32d8492b1bdcc956ca3c6d00c6392d0a83942ff11d4820c7ee63ca6796e06950",
-    "zh:3c0482e894429f528ce6655a76ab0d8a9f7c0dacc6c828865e1515d4a7dbb852",
-    "zh:61e68100b4db2f930b31491f23c602126382fd5e51252be1b551f0e17f8ddbee",
-    "zh:6d60f615a0ad85eb962c9eb94f25e3eba7a72684ce276ba5dfb23f36b295a8f8",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9ced2745eb5f1346203027d2dd7bf856ad1d279a25730ff7dbc6eec187aaca0c",
-    "zh:a8378558a177d43f55aa0d79d4fae91a704695122a1b109668c1daa8fb76f09d",
-    "zh:aadd98086133d3ebea67437d56512fdcc6dfb3bd34dfc23f276c0db9272e27b4",
-    "zh:beff701b653841e70441978137768f54e7dc6c27e7bf12a4589087f01f5bbcee",
-    "zh:c91c2223b29fdbc0044d20e1936ccc051d010727a13f2ff1e75e51f09bff33a3",
-    "zh:d491f9c2d32a39dc4031628469ae7c8aec0074312a7c1f0286b173cdcf854a54",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.9.0"
-  constraints = "~> 3.9.0"
-  hashes = [
-    "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
-    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
-    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
-    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
-    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
-    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
-    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
-    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
-    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
-    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
-    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
-    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+    "h1:JQSzisQQJATfDuN1voS1ZvXGrJnLjaFbtcwx+fiMr9w=",
+    "zh:0017ae6dcdcf320df10dd0a24f22dd7f1bd92cc62c2550f5696888d7bb042d81",
+    "zh:00574d8102685054080ad68db5ee99f1ee02c07709d3f77324be2d134eddf0d4",
+    "zh:0a9b84dccbfe0e704a81c1e76f75c95efdc4bf03c6a1a210b1b386dfd1593209",
+    "zh:2426358421619cb9125f2145f567908a904fd2a51e86c0afdf92082ea0532e9d",
+    "zh:425794426f7bb78921b3329c82f6373d5a5f072f28cc7296fdb21e13c595c0e8",
+    "zh:64d1a85a356ab75e84f12cbab41c548e069609098279eb5360c295b06a6f2994",
+    "zh:71612774c04cdeae2520a0ea19f938c17b9f6600eaa0356905f40d35caca1e81",
+    "zh:8d841d44c929bc4882d05c59ddd1bb1b91174c96139500ba29daacf74cf91406",
+    "zh:97ed1034b0962be59d2e03221031cb49f2ac9e992392bab3b08cbce9fa15e244",
+    "zh:9daebe55771a8e5b7b21c59cd53d86af9a1435e903ca60de119ccb3bc73a87b8",
+    "zh:a2d477ed687592a392439c7f96e378c9aa356151f7b2b44dcebc9aae956018e0",
+    "zh:c0f7e2656593ac97db96d82da41d8a3bd6584406f6d944b02d14ab132b3043ad",
+    "zh:cc24f9cd5ba535fbdb1bcabea69c5f150b43004ed180a3d14d740700d0d1a4b7",
+    "zh:cd7283a1a9fb857eb0c2e436ad9859b557127b594a1c7f818c1cb7a20df1c724",
   ]
 }

--- a/terraform/module/aws_iam_user_for_vm/aws_iam_user_for_vm.tf
+++ b/terraform/module/aws_iam_user_for_vm/aws_iam_user_for_vm.tf
@@ -5,13 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
-    external = {
-      source  = "hashicorp/external"
-      version = "~> 2.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
+    shell = {
+      source  = "scottwinkler/shell"
+      version = "~> 1.7"
     }
   }
 }
@@ -33,6 +29,12 @@ variable "sts_token_duration" {
     condition     = floor(var.sts_token_duration) == var.sts_token_duration && var.sts_token_duration >= 900 && var.sts_token_duration <= 43200
     error_message = "sts_token_duration must be an integer between 900 and 43200 (inclusive)"
   }
+}
+
+variable "triggers" {
+  description = "Map of values that, when changed, cause the STS token to be regenerated. Pass the ID of the associated VM to tie the token lifecycle to the VM."
+  type        = map(string)
+  default     = {}
 }
 
 data "aws_caller_identity" "mod_scope" {}
@@ -86,25 +88,20 @@ resource "aws_iam_role_policy" "key_manager" {
 }
 
 #####
-# STS token returned by module outputs for passing into user-data
-resource "random_string" "role_session_suffix" {
-  length  = 15
-  special = false
-}
+# STS token stored in state for passing into user-data; only regenerated when triggers change
 
-data "external" "key_manager_sts_token" {
-  program = [
-    "bash", "-c",
-    <<-EOT
+resource "shell_script" "key_manager_sts_token" {
+  lifecycle_commands {
+    create = <<-EOT
       set -o pipefail
-      # It takes AWS a few seconds, typically, to have new IAM roles ready to use, even after the
-      # API responds and the role is visible in the AWS control plane.  Sleep 10s before the FIRST
-      # ATTEMPT and retry up to 10 times.
+      SESSION_SUFFIX=$(openssl rand -hex 8 | head -c 15)
+      # IAM roles take a few seconds to propagate after creation. Sleep before the first
+      # attempt and retry up to 10 times.
       for i in $(seq 1 10); do
         sleep 10
         if output=$(aws sts assume-role \
             --role-arn ${aws_iam_role.key_manager.arn} \
-            --role-session-name ${substr(var.name, 0, 48)}_${random_string.role_session_suffix.result} \
+            --role-session-name ${substr(var.name, 0, 48)}_$SESSION_SUFFIX \
             --duration-seconds ${var.sts_token_duration} \
             | jq '.Credentials + .AssumedRoleUser'); then
           printf '%s\n' "$output"
@@ -113,12 +110,22 @@ data "external" "key_manager_sts_token" {
       done
       exit 1
     EOT
-  ]
-  depends_on = [aws_iam_role.key_manager, aws_iam_role_policy.key_manager]
+    delete = ":"
+  }
+
+  triggers   = var.triggers
+  depends_on = [aws_iam_role_policy.key_manager]
 }
 
 output "key_manager" {
-  value = data.external.key_manager_sts_token.result
+  value = {
+    AccessKeyId     = shell_script.key_manager_sts_token.output["AccessKeyId"]
+    SecretAccessKey = shell_script.key_manager_sts_token.output["SecretAccessKey"]
+    SessionToken    = shell_script.key_manager_sts_token.output["SessionToken"]
+    Expiration      = shell_script.key_manager_sts_token.output["Expiration"]
+    AssumedRoleId   = shell_script.key_manager_sts_token.output["AssumedRoleId"]
+    Arn             = shell_script.key_manager_sts_token.output["Arn"]
+  }
   type = object({
     AccessKeyId     = string
     SecretAccessKey = string

--- a/terraform/module/aws_iam_user_for_vm/tests/e2e.tftest.hcl
+++ b/terraform/module/aws_iam_user_for_vm/tests/e2e.tftest.hcl
@@ -7,8 +7,7 @@ provider "aws" {
     }
   }
 }
-provider "external" {}
-provider "random" {}
+provider "shell" {}
 
 run "creates_iam_resources_and_sts_token" {
   command = apply
@@ -27,12 +26,12 @@ run "creates_iam_resources_and_sts_token" {
   }
 
   assert {
-    condition     = length(data.external.key_manager_sts_token.result["AccessKeyId"]) > 0
+    condition     = length(shell_script.key_manager_sts_token.output["AccessKeyId"]) > 0
     error_message = "sts assume-role did not return an AccessKeyId"
   }
 
   assert {
-    condition     = length(data.external.key_manager_sts_token.result["SessionToken"]) > 0
+    condition     = length(shell_script.key_manager_sts_token.output["SessionToken"]) > 0
     error_message = "sts assume-role did not return a SessionToken"
   }
 }

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.tf
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.tf
@@ -38,9 +38,22 @@ variable "opensearch_admin_password" {
   type        = string
 }
 
+variable "diff_import_es_username" {
+  description = "OpenSearch username for the diff_import_from_sqs cron job (e.g. vm-opensearch-1-dev)"
+  type        = string
+  default     = "vm-opensearch-1-dev"
+}
+
+variable "diff_import_es_password" {
+  description = "OpenSearch password for the diff_import_from_sqs cron job"
+  type        = string
+}
+
 locals {
   user_data_opensearch_1 = {
     console_password_plaintext        = nonsensitive(var.console_password_plaintext)
+    diff_import_es_username           = var.diff_import_es_username
+    diff_import_es_password           = var.diff_import_es_password
     fqdn                              = var.fqdn
     key_manager_aws_access_key_id     = var.key_manager_aws_access_key_id
     key_manager_aws_secret_access_key = var.key_manager_aws_secret_access_key

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.tf
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.tf
@@ -13,6 +13,26 @@ variable "fqdn" {
   default     = null
 }
 
+variable "key_manager_aws_access_key_id" {
+  description = "Ephemeral STS access key ID for the key-manager role; used by 100_aws_key_manager.py to provision rpkilog user credentials"
+  type        = string
+}
+
+variable "key_manager_aws_secret_access_key" {
+  description = "Ephemeral STS secret access key for the key-manager role"
+  type        = string
+}
+
+variable "key_manager_aws_session_token" {
+  description = "Ephemeral STS session token for the key-manager role"
+  type        = string
+}
+
+variable "opensearch_1_iam_username" {
+  description = "IAM username for the opensearch-1 VM user (e.g. opensearch_1_dev); written into the key-manager wrapper script"
+  type        = string
+}
+
 variable "opensearch_admin_password" {
   description = "Initial admin password passed to OPENSEARCH_INITIAL_ADMIN_PASSWORD when starting the container"
   type        = string
@@ -20,10 +40,16 @@ variable "opensearch_admin_password" {
 
 locals {
   user_data_opensearch_1 = {
-    console_password_plaintext = nonsensitive(var.console_password_plaintext)
-    fqdn                       = var.fqdn
-    opensearch_admin_password  = var.opensearch_admin_password
-    script_install_opensearch  = "${path.module}/../../../scripts/install_opensearch.sh"
+    console_password_plaintext        = nonsensitive(var.console_password_plaintext)
+    fqdn                              = var.fqdn
+    key_manager_aws_access_key_id     = var.key_manager_aws_access_key_id
+    key_manager_aws_secret_access_key = var.key_manager_aws_secret_access_key
+    key_manager_aws_session_token     = var.key_manager_aws_session_token
+    opensearch_1_iam_username         = var.opensearch_1_iam_username
+    opensearch_admin_password         = var.opensearch_admin_password
+    script_install_opensearch         = "${path.module}/../../../scripts/install_opensearch.sh"
+    script_install_rpkilog            = "${path.module}/../../../scripts/install_rpkilog.sh"
+    script_key_manager                = "${path.module}/../../../scripts/aws_key_manager.py"
   }
 }
 

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
@@ -41,7 +41,15 @@ packages:
   - htop
   - incus-agent
   - openssh-server
+  - python3-full
+  - python3-pip
+  - python3-venv
+  - run-one
   - ssh-import-id
+  - unzip
+runcmd:
+  # ensure /home/rpkilog/.aws and other directories we may be creating with cloud-init have correct ownership
+  - "chown -R rpkilog:rpkilog /home/rpkilog"
 ssh_pwauth: false
 users:
   - name: opensearch
@@ -60,7 +68,48 @@ users:
     sudo: "ALL=(ALL) NOPASSWD: ALL"
     ssh_authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4k8nVaS9Ns+8jZ1C97eUcOvkFw6NOXS8e4xxG6XEH1l9PDluOCxAqgCvdKxX9ZhFvwW1SCSWuN95WrM7u/9p0flOX7DZFYld053ClWxMZZ4ZtKj8XWnmDU4LLXSmUWaKddW9pHZHvxfEFu+wCcnUiJM4NgS4owfaIGC3IOIXVrxsoNuoKyTQS9pRa5+3sMC3rHK8oWPkleJGO+cs8AxuetRtHS/ZHwshsyI27ROC/nIxZ7ZeKXf3g/jxEpbxI9LNFnocuUmeoNpndBFYND1ujwiHZvoWxx4ByiTRDNJDHJWdnJpz8rOmnoHeHFqV8F/I5CRG9Dh7aq5vd9LWdrkqb jeffsw6@gmail.com boomer 2013-05-28
+  - name: rpkilog
+    shell: /usr/bin/bash
 write_files:
+  - path: /root/.aws/config
+    owner: root:root
+    permissions: '0600'
+    content: |4
+        [default]
+        region = us-east-1
+  - path: /root/.aws/credentials
+    owner: root:root
+    permissions: '0600'
+    content: |4
+        [default]
+        aws_access_key_id = ${key_manager_aws_access_key_id}
+        aws_secret_access_key = ${key_manager_aws_secret_access_key}
+        aws_session_token = ${key_manager_aws_session_token}
+  - path: /usr/local/bin/100_aws_key_manager.py
+    permissions: "0755"
+    content: |4
+        ${indent(8, file(script_key_manager))}
+  - path: /var/lib/cloud/scripts/per-once/100_install_rpkilog.sh
+    permissions: "0755"
+    content: |4
+        ${indent(8, file(script_install_rpkilog))}
+  - path: /home/rpkilog/.aws/config
+    defer: true
+    owner: rpkilog:rpkilog
+    permissions: '0600'
+    content: |4
+        [default]
+        region = us-east-1
+  - path: /var/lib/cloud/scripts/per-once/100_aws_key_manager_wrapper.sh
+    defer: true
+    permissions: "0755"
+    content: |4
+        #!/bin/bash -e
+        /usr/local/bin/100_aws_key_manager.py \
+          --username ${opensearch_1_iam_username} \
+          --cred-file-path /home/rpkilog/.aws/credentials \
+          --cred-file-owner rpkilog \
+          --cred-file-group rpkilog
   - path: /etc/profile.d/rpkilog_prompt.sh
     permissions: '0644'
     content: |4

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
@@ -134,4 +134,4 @@ write_files:
     content: |4
         ES_USERNAME=${diff_import_es_username}
         ES_PASSWORD=${diff_import_es_password}
-        */5 * * * * rpkilog run-one /opt/rpkilog/venv/bin/rpkilog-diff-import-from-sqs --sqs-name diff_dev --es-endpoint localhost:9200 --dry-run 2>&1 | logger -t diff_import_from_sqs
+        */5 * * * * rpkilog run-one /opt/rpkilog/venv/bin/rpkilog-diff-import-from-sqs --sqs-name diff_dev --es-endpoint https://localhost:9200 --no-es-ssl-verify --dry-run 2>&1 | logger -t diff_import_from_sqs

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
@@ -134,4 +134,4 @@ write_files:
     content: |4
         ES_USERNAME=${diff_import_es_username}
         ES_PASSWORD=${diff_import_es_password}
-        */5 * * * * rpkilog run-one /opt/rpkilog/venv/bin/rpkilog-diff-import-from-sqs --sqs-name diff_dev --es-endpoint https://localhost:9200 --no-es-ssl-verify --dry-run 2>&1 | logger -t diff_import_from_sqs
+        */5 * * * * rpkilog run-one /opt/rpkilog/venv/bin/rpkilog-diff-import-from-sqs --sqs-name diff_dev --es-endpoint https://localhost:9200 --no-es-ssl-verify 2>&1 | logger -t diff_import_from_sqs

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
@@ -128,3 +128,10 @@ write_files:
         #!/bin/bash -e
         export OPENSEARCH_INITIAL_ADMIN_PASSWORD='${opensearch_admin_password}'
         /usr/local/bin/install_opensearch.sh
+  - path: /etc/cron.d/diff_import_from_sqs
+    owner: root:root
+    permissions: '0644'
+    content: |4
+        ES_USERNAME=${diff_import_es_username}
+        ES_PASSWORD=${diff_import_es_password}
+        */5 * * * * rpkilog run-one /opt/rpkilog/venv/bin/rpkilog-diff-import-from-sqs --sqs-name diff_dev --es-endpoint localhost:9200 --dry-run 2>&1 | logger -t diff_import_from_sqs

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
@@ -34,6 +34,7 @@ package_reboot_if_required: true
 package_update: true
 package_upgrade: true
 packages:
+  - bzip2
   - ca-certificates
   - curl
   - docker-ce
@@ -41,6 +42,9 @@ packages:
   - htop
   - incus-agent
   - openssh-server
+  - python3-bcdoc
+  - python3-boto3
+  - python3-botocore
   - python3-full
   - python3-pip
   - python3-venv

--- a/terraform/root/dev/.terraform.lock.hcl
+++ b/terraform/root/dev/.terraform.lock.hcl
@@ -108,3 +108,25 @@ provider "registry.terraform.io/opensearch-project/opensearch" {
     "zh:f4e68dc18db765841e49cad7b4aa5385a94bf974e05af14ef87e5509bbed7790",
   ]
 }
+
+provider "registry.terraform.io/scottwinkler/shell" {
+  version     = "1.7.10"
+  constraints = "~> 1.7"
+  hashes = [
+    "h1:JQSzisQQJATfDuN1voS1ZvXGrJnLjaFbtcwx+fiMr9w=",
+    "zh:0017ae6dcdcf320df10dd0a24f22dd7f1bd92cc62c2550f5696888d7bb042d81",
+    "zh:00574d8102685054080ad68db5ee99f1ee02c07709d3f77324be2d134eddf0d4",
+    "zh:0a9b84dccbfe0e704a81c1e76f75c95efdc4bf03c6a1a210b1b386dfd1593209",
+    "zh:2426358421619cb9125f2145f567908a904fd2a51e86c0afdf92082ea0532e9d",
+    "zh:425794426f7bb78921b3329c82f6373d5a5f072f28cc7296fdb21e13c595c0e8",
+    "zh:64d1a85a356ab75e84f12cbab41c548e069609098279eb5360c295b06a6f2994",
+    "zh:71612774c04cdeae2520a0ea19f938c17b9f6600eaa0356905f40d35caca1e81",
+    "zh:8d841d44c929bc4882d05c59ddd1bb1b91174c96139500ba29daacf74cf91406",
+    "zh:97ed1034b0962be59d2e03221031cb49f2ac9e992392bab3b08cbce9fa15e244",
+    "zh:9daebe55771a8e5b7b21c59cd53d86af9a1435e903ca60de119ccb3bc73a87b8",
+    "zh:a2d477ed687592a392439c7f96e378c9aa356151f7b2b44dcebc9aae956018e0",
+    "zh:c0f7e2656593ac97db96d82da41d8a3bd6584406f6d944b02d14ab132b3043ad",
+    "zh:cc24f9cd5ba535fbdb1bcabea69c5f150b43004ed180a3d14d740700d0d1a4b7",
+    "zh:cd7283a1a9fb857eb0c2e436ad9859b557127b594a1c7f818c1cb7a20df1c724",
+  ]
+}

--- a/terraform/root/dev/opensearch_1.tf
+++ b/terraform/root/dev/opensearch_1.tf
@@ -41,11 +41,65 @@ output "opensearch_1_console_password" {
   value       = nonsensitive(random_password.opensearch_1_console.result)
 }
 
+data "aws_s3_bucket" "rpkilog_diff" {
+  bucket = "rpkilog-diff"
+}
+
+data "aws_sqs_queue" "diff_dev" {
+  name = "diff_dev"
+}
+
+module "opensearch_1_iam_user" {
+  source = "../../module/aws_iam_user_for_vm"
+  name   = "opensearch_1_${terraform.workspace}"
+}
+
+resource "aws_iam_policy" "opensearch_1" {
+  name = "opensearch_1_${terraform.workspace}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          data.aws_s3_bucket.rpkilog_diff.arn,
+          "${data.aws_s3_bucket.rpkilog_diff.arn}/*",
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:ChangeMessageVisibility",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:ReceiveMessage",
+        ]
+        Resource = data.aws_sqs_queue.diff_dev.arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "opensearch_1" {
+  user       = module.opensearch_1_iam_user.user.name
+  policy_arn = aws_iam_policy.opensearch_1.arn
+}
+
 module "userdata_opensearch_1" {
-  source                     = "../../module/opensearch_1_userdata"
-  console_password_plaintext = nonsensitive(random_password.opensearch_1_console.result)
-  fqdn                       = "opensearch-1.rpkilog.dev"
-  opensearch_admin_password  = nonsensitive(random_password.opensearch_1_admin.result)
+  source                            = "../../module/opensearch_1_userdata"
+  console_password_plaintext        = nonsensitive(random_password.opensearch_1_console.result)
+  fqdn                              = "opensearch-1.rpkilog.dev"
+  key_manager_aws_access_key_id     = module.opensearch_1_iam_user.key_manager.AccessKeyId
+  key_manager_aws_secret_access_key = module.opensearch_1_iam_user.key_manager.SecretAccessKey
+  key_manager_aws_session_token     = module.opensearch_1_iam_user.key_manager.SessionToken
+  opensearch_1_iam_username         = module.opensearch_1_iam_user.user.name
+  opensearch_admin_password         = nonsensitive(random_password.opensearch_1_admin.result)
 }
 
 # https://registry.terraform.io/providers/lxc/incus/latest/docs/resources/instance
@@ -86,12 +140,42 @@ resource "aws_route53_record" "opensearch_1_A" {
   records = [incus_instance.opensearch_1.ipv4_address]
 }
 
+# Poll /_cluster/health until OpenSearch is accepting connections before
+# allowing the opensearch provider resources below to run.  The VM boots and
+# runs cloud-init (package upgrades, Docker pull, container start) before
+# OpenSearch is reachable, so a simple depends_on the instance is not enough.
+resource "terraform_data" "opensearch_1_ready" {
+  lifecycle {
+    replace_triggered_by = [incus_instance.opensearch_1]
+  }
+
+  provisioner "local-exec" {
+    environment = {
+      OS_PASSWORD = random_password.opensearch_1_admin.result
+    }
+    command = <<-EOT
+      echo "Waiting for OpenSearch at opensearch-1.rpkilog.dev:9200..."
+      until curl -sk -u "admin:$OS_PASSWORD" \
+          https://opensearch-1.rpkilog.dev:9200/_cluster/health \
+          | grep -q '"status"'; do
+        echo "  not ready yet, retrying in 15s..."
+        sleep 15
+      done
+      echo "OpenSearch is ready."
+    EOT
+  }
+
+  depends_on = [incus_instance.opensearch_1]
+}
+
 resource "opensearch_cluster_settings" "opensearch_1" {
   search_default_search_timeout = "30s"
+  depends_on                    = [terraform_data.opensearch_1_ready]
 }
 
 resource "opensearch_index_template" "diff" {
-  name = "diff"
+  name       = "diff"
+  depends_on = [terraform_data.opensearch_1_ready]
   body = jsonencode({
     index_patterns : ["diff-*"],
     template : {
@@ -104,15 +188,15 @@ resource "opensearch_index_template" "diff" {
       mappings : {
         properties : {
           observation_timestamp : { type : "date", format : "strict_date_time_no_millis" },
-          verb                  : { type : "keyword" },
-          prefix                : { type : "ip_range" },
-          maxLength             : { type : "integer" },
-          asn                   : { type : "long" },
-          ta                    : { type : "keyword" },
-          old_expires           : { type : "date", format : "strict_date_time_no_millis" },
-          new_expires           : { type : "date", format : "strict_date_time_no_millis" },
-          old_roa               : { type : "object" },
-          new_roa               : { type : "object" },
+          verb : { type : "keyword" },
+          prefix : { type : "ip_range" },
+          maxLength : { type : "integer" },
+          asn : { type : "long" },
+          ta : { type : "keyword" },
+          old_expires : { type : "date", format : "strict_date_time_no_millis" },
+          new_expires : { type : "date", format : "strict_date_time_no_millis" },
+          old_roa : { type : "object" },
+          new_roa : { type : "object" },
         }
       }
     }

--- a/terraform/root/dev/opensearch_1.tf
+++ b/terraform/root/dev/opensearch_1.tf
@@ -5,6 +5,10 @@ provider "opensearch" {
   password = random_password.opensearch_1_admin.result
 }
 
+locals {
+  diff_import_es_username = "vm-opensearch-1-${terraform.workspace}"
+}
+
 resource "incus_storage_volume" "opensearch_1_volume_1" {
   name         = "opensearch-1-volume-1"
   pool         = data.incus_storage_pool.default.name
@@ -26,6 +30,19 @@ resource "random_password" "opensearch_1_admin" {
 output "opensearch_1_admin_password" {
   description = "OpenSearch initial admin password (OPENSEARCH_INITIAL_ADMIN_PASSWORD)"
   value       = nonsensitive(random_password.opensearch_1_admin.result)
+}
+
+resource "random_string" "opensearch_1_diff_import_password" {
+  length  = 24
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
+output "opensearch_1_diff_import_password" {
+  description = "Password for OpenSearch user vm-opensearch-1-dev used by the diff_import_from_sqs cron job"
+  value       = random_string.opensearch_1_diff_import_password.result
 }
 
 resource "random_password" "opensearch_1_console" {
@@ -100,6 +117,8 @@ module "userdata_opensearch_1" {
   key_manager_aws_session_token     = module.opensearch_1_iam_user.key_manager.SessionToken
   opensearch_1_iam_username         = module.opensearch_1_iam_user.user.name
   opensearch_admin_password         = nonsensitive(random_password.opensearch_1_admin.result)
+  diff_import_es_username           = local.diff_import_es_username
+  diff_import_es_password           = random_string.opensearch_1_diff_import.result
 }
 
 # https://registry.terraform.io/providers/lxc/incus/latest/docs/resources/instance
@@ -171,6 +190,32 @@ resource "terraform_data" "opensearch_1_ready" {
 resource "opensearch_cluster_settings" "opensearch_1" {
   search_default_search_timeout = "30s"
   depends_on                    = [terraform_data.opensearch_1_ready]
+}
+
+resource "opensearch_role" "diff_import" {
+  role_name   = "diff_import"
+  description = "Read, write, and create-index on diff-* indices; cluster monitor for health checks"
+  depends_on  = [terraform_data.opensearch_1_ready]
+
+  cluster_permissions = ["cluster_monitor"]
+
+  index_permissions {
+    index_patterns  = ["diff-*"]
+    allowed_actions = ["read", "write", "create_index"]
+  }
+}
+
+resource "opensearch_user" "diff_import" {
+  username    = local.diff_import_es_username
+  password    = random_string.opensearch_1_diff_import.result
+  description = "Service account for the diff_import_from_sqs cron job on opensearch-1.rpkilog.dev"
+  depends_on  = [terraform_data.opensearch_1_ready]
+}
+
+resource "opensearch_roles_mapping" "diff_import" {
+  role_name  = opensearch_role.diff_import.role_name
+  users      = [opensearch_user.diff_import.username]
+  depends_on = [terraform_data.opensearch_1_ready]
 }
 
 resource "opensearch_index_template" "diff" {

--- a/terraform/root/dev/opensearch_1.tf
+++ b/terraform/root/dev/opensearch_1.tf
@@ -223,6 +223,23 @@ resource "opensearch_roles_mapping" "diff_import" {
   depends_on = [terraform_data.opensearch_1_ready]
 }
 
+resource "opensearch_dashboard_object" "diff_index_pattern" {
+  tenant_name = ""
+  body = jsonencode([
+    {
+      _id = "index-pattern:diff-*"
+      _source = {
+        type = "index-pattern"
+        "index-pattern" = {
+          title         = "diff-*"
+          timeFieldName = "observation_timestamp"
+        }
+      }
+    }
+  ])
+  depends_on = [terraform_data.opensearch_1_ready]
+}
+
 resource "opensearch_index_template" "diff" {
   name       = "diff"
   depends_on = [terraform_data.opensearch_1_ready]

--- a/terraform/root/dev/opensearch_1.tf
+++ b/terraform/root/dev/opensearch_1.tf
@@ -181,8 +181,8 @@ resource "opensearch_index_template" "diff" {
     template : {
       settings : {
         index : {
-          number_of_shards : 1,
-          number_of_replicas : 0,
+          number_of_shards : "1",
+          number_of_replicas : "0",
         }
       }
       mappings : {

--- a/terraform/root/dev/opensearch_1.tf
+++ b/terraform/root/dev/opensearch_1.tf
@@ -32,7 +32,7 @@ output "opensearch_1_admin_password" {
   value       = nonsensitive(random_password.opensearch_1_admin.result)
 }
 
-resource "random_string" "opensearch_1_diff_import_password" {
+resource "random_string" "opensearch_1_diff_import" {
   length  = 24
   lower   = true
   upper   = false
@@ -40,9 +40,14 @@ resource "random_string" "opensearch_1_diff_import_password" {
   special = false
 }
 
+output "opensearch_1_diff_import_username" {
+  description = "OpenSearch username for the diff_import_from_sqs cron job"
+  value       = local.diff_import_es_username
+}
+
 output "opensearch_1_diff_import_password" {
-  description = "Password for OpenSearch user vm-opensearch-1-dev used by the diff_import_from_sqs cron job"
-  value       = random_string.opensearch_1_diff_import_password.result
+  description = "OpenSearch password for the diff_import_from_sqs cron job"
+  value       = random_string.opensearch_1_diff_import.result
 }
 
 resource "random_password" "opensearch_1_console" {


### PR DESCRIPTION
- Create dev DB user, role, roles mapping, and index pattern
- Add HTTP basic auth support to rpkilog-diff-import-from-sqs
- Other minor improvements to rpkilog-diff-import-from-sqs
- Add cron job for rpkilog-diff-import-from-sqs to opensearch-1.rpkilog.dev
- Add [mise](https://github.com/jdx/mise) tasks for dev VM replacement, simplifying dev workflow
