### PR TITLE
GH-76: dead letter queues for SQS queues and Lambdas

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Bash(python -m pytest tests/test_vrp_diff_list.py -v -m slow)",
       "Bash(python -m pytest tests/test_vrp_diff_list.py -v)",
       "Bash(python -m pytest tests/test_vrp_diff_list.py -v -m \"not slow\")",
-      "WebFetch(domain:registry.terraform.io)"
+      "WebFetch(domain:registry.terraform.io)",
+      "Bash(terraform fmt *)",
+      "Bash(terraform validate *)"
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -740,6 +740,24 @@ resource "aws_sqs_queue" "snapshot_summary_dev" {
   name                       = "snapshot_summary_dev"
   message_retention_seconds  = 86400 * 14
   visibility_timeout_seconds = 300
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.sqs_dlq_snapshot_summary_dev.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue" "sqs_dlq_snapshot_summary_dev" {
+  name                       = "sqs_dlq_snapshot_summary_dev"
+  message_retention_seconds  = 86400 * 14
+  visibility_timeout_seconds = 300
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "sqs_dlq_snapshot_summary_dev" {
+  queue_url = aws_sqs_queue.sqs_dlq_snapshot_summary_dev.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.snapshot_summary_dev.arn]
+  })
 }
 
 resource "aws_sqs_queue_policy" "snapshot_summary_dev" {
@@ -751,6 +769,24 @@ resource "aws_sqs_queue" "snapshot_summary_prod" {
   name                       = "snapshot_summary_prod"
   message_retention_seconds  = 86400 * 14
   visibility_timeout_seconds = 300
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.sqs_dlq_snapshot_summary_prod.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue" "sqs_dlq_snapshot_summary_prod" {
+  name                       = "sqs_dlq_snapshot_summary_prod"
+  message_retention_seconds  = 86400 * 14
+  visibility_timeout_seconds = 300
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "sqs_dlq_snapshot_summary_prod" {
+  queue_url = aws_sqs_queue.sqs_dlq_snapshot_summary_prod.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.snapshot_summary_prod.arn]
+  })
 }
 
 resource "aws_sqs_queue_policy" "snapshot_summary_prod" {
@@ -857,12 +893,48 @@ resource "aws_sqs_queue" "diff_dev" {
   name                       = "diff_dev"
   message_retention_seconds  = 86400 * 14
   visibility_timeout_seconds = 300
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.sqs_dlq_diff_dev.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue" "sqs_dlq_diff_dev" {
+  name                       = "sqs_dlq_diff_dev"
+  message_retention_seconds  = 86400 * 14
+  visibility_timeout_seconds = 300
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "sqs_dlq_diff_dev" {
+  queue_url = aws_sqs_queue.sqs_dlq_diff_dev.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.diff_dev.arn]
+  })
 }
 
 resource "aws_sqs_queue" "diff_prod" {
   name                       = "diff_prod"
   message_retention_seconds  = 86400 * 14
   visibility_timeout_seconds = 300
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.sqs_dlq_diff_prod.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue" "sqs_dlq_diff_prod" {
+  name                       = "sqs_dlq_diff_prod"
+  message_retention_seconds  = 86400 * 14
+  visibility_timeout_seconds = 300
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "sqs_dlq_diff_prod" {
+  queue_url = aws_sqs_queue.sqs_dlq_diff_prod.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.diff_prod.arn]
+  })
 }
 
 data "aws_iam_policy_document" "sqs_diff_sns_send" {

--- a/main.tf
+++ b/main.tf
@@ -492,7 +492,7 @@ resource "aws_iam_policy" "lambda_vrp_cache_diff" {
           "sqs:SendMessage"
         ]
         Resource = [
-          aws_sqs_queue.lambda_dlq_for_vrp_cache_diff.arn
+          aws_sqs_queue.lambda_dlq_vrp_cache_diff_prod.arn
         ]
       },
       {
@@ -558,6 +558,16 @@ resource "aws_iam_policy" "lambda_diff_import" {
         ]
         Resource : [
           "arn:aws:logs:*:*:*",
+        ]
+      },
+      {
+        Sid    = "DeadLetterQueue"
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage"
+        ]
+        Resource = [
+          aws_sqs_queue.lambda_dlq_diff_import_prod.arn
         ]
       }
     ]
@@ -710,17 +720,20 @@ resource "aws_iam_group_membership" "es_master" {
 }
 
 ##############################
-# SNS
-resource "aws_sns_topic" "lambda_dead_letter_queue_for_diff" {
-  name = "lambda_dead_letter_queue_for_diff"
+# SQS
+# Dead-letter queues receiving on_failure Lambda Destination messages from our
+# asynchronously-invoked lambdas.  Messages are sent by each lambda's execution role,
+# which must have sqs:SendMessage permission on its queue.
+resource "aws_sqs_queue" "lambda_dlq_vrp_cache_diff_prod" {
+  name                       = "lambda_dlq_vrp_cache_diff_prod"
+  message_retention_seconds  = 86400 * 14
+  visibility_timeout_seconds = 300
 }
 
-##############################
-# SQS
-resource "aws_sqs_queue" "lambda_dlq_for_vrp_cache_diff" {
-  name                      = "lambda_dlq_for_vrp_cache_diff"
-  max_message_size          = 2048
-  message_retention_seconds = 1209600 # 14 days
+resource "aws_sqs_queue" "lambda_dlq_diff_import_prod" {
+  name                       = "lambda_dlq_diff_import_prod"
+  message_retention_seconds  = 86400 * 14
+  visibility_timeout_seconds = 300
 }
 
 resource "aws_sqs_queue" "snapshot_summary_dev" {
@@ -1236,9 +1249,6 @@ resource "aws_lambda_function" "vrp_cache_diff" {
       diff_bucket             = aws_s3_bucket.rpkilog_diff.id
     }
   }
-  dead_letter_config {
-    target_arn = aws_sqs_queue.lambda_dlq_for_vrp_cache_diff.arn
-  }
   lifecycle {
     # Never update the lambda deployment package.  We use another tool for that, not Terraform.
     ignore_changes = [filename]
@@ -1264,6 +1274,11 @@ resource "aws_lambda_permission" "vrp_cache_diff_from_sns" {
 resource "aws_lambda_function_event_invoke_config" "vrp_cache_diff" {
   function_name          = aws_lambda_function.vrp_cache_diff.function_name
   maximum_retry_attempts = 0
+  destination_config {
+    on_failure {
+      destination = aws_sqs_queue.lambda_dlq_vrp_cache_diff_prod.arn
+    }
+  }
 }
 
 resource "aws_lambda_function" "diff_import" {
@@ -1302,6 +1317,11 @@ resource "aws_lambda_permission" "diff_import_from_sns" {
 resource "aws_lambda_function_event_invoke_config" "diff_import" {
   function_name          = aws_lambda_function.diff_import.function_name
   maximum_retry_attempts = 0
+  destination_config {
+    on_failure {
+      destination = aws_sqs_queue.lambda_dlq_diff_import_prod.arn
+    }
+  }
 }
 
 ##############################

--- a/python/rpkilog/uv.lock
+++ b/python/rpkilog/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "rpkilog"
-version = "0.26060701"
+version = "0.26060702"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
* modernized Lambda vrp_cache_diff DLQ configuration
* added DLQ for Lambda diff_import
* added DLQs for our recently-created SQS queues, providing a DLQ path for non-Lambda consumption, and a way to avoid a Lambda getting stuck trying to process the same message over and over