### PR TITLE
Refactor rpkiclient_uploader onto SnapshotSummaryFile 

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -45,14 +45,11 @@ jobs:
               # un-comment as they are merged.
               #
               python/rpkilog/rpkilog/data_file_super.py
-              # python/rpkilog/rpkilog/diff_file.py
-              # python/rpkilog/rpkilog/diff_import_to_pgsql.py
               python/rpkilog/rpkilog/local_storage_type.py
               python/rpkilog/rpkilog/roa.py
-              # python/rpkilog/rpkilog/routinator_snapshot_file.py
-              # python/rpkilog/rpkilog/routinator_vrp_fetcher.py
-              # python/rpkilog/rpkilog/summary_file.py
+              python/rpkilog/rpkilog/snapshot_summary_file.py
               python/rpkilog/rpkilog/util.py
+              python/rpkilog/rpkilog/vrp_diff_file.py
               python/rpkilog/tests
           )
           flake8 --count --show-source --statistics "${LINT_FILES[@]}"

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -64,14 +64,14 @@ jobs:
         if: github.event.pull_request.draft == true
         timeout-minutes: 15
         run: |
-          pushd python/
+          pushd python/rpkilog/
           pytest --verbose -m "not slow"
           popd
       - name: Test with pytest, including slow tests
         if: github.event.pull_request.draft == false
         timeout-minutes: 15
         run: |
-          pushd python/
+          pushd python/rpkilog/
           pytest --verbose
           popd
       #####

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,5 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
+        exclude: '\.svg$'
       - id: no-commit-to-branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ Prefer bullet points over prose.
 
 There are standard pre-commit hooks in this repository.  They can be invoked manually with: `uv run --directory python/rpkilog prek run` which is a good way to perform basic verifications after edits, too.
 
+Prefer scoping a manual run to the files you changed (`prek run --files <abs-path> ...`) rather than
+`prek run --all-files`.  A number of committed text files (SVGs are excluded, but various HTML, CSS,
+config, and test-data files) lack a trailing newline, so `--all-files` makes `end-of-file-fixer`
+churn files unrelated to your change.
+
 ## Python
 
 ### Style Guide
@@ -34,6 +39,14 @@ alright default choices.
 #### Enums
 
 Use Docstrings on Enum members to describe the values.
+
+### Testing
+
+The golden file `test_data/rpkiclient_summary_20250720T100145Z.json.bz2` has an internal
+`metadata.buildtime` of `20250720T100143Z` — two seconds earlier than the `100145Z` in its filename.
+Code that derives a filename/S3 key from the JSON buildtime (e.g. `rpkiclient_uploader.s3_upload` via
+`SnapshotSummaryFile.datetimestamp_from_json()`) therefore produces a `100143Z` key, not `100145Z`.
+Tests that assert against such a key should compute it from the JSON buildtime, not the filename.
 
 ## Reviewing PRs or branches
 

--- a/python/rpkilog/pyproject.toml
+++ b/python/rpkilog/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'rpkilog'
-version = '0.26060702'
+version = '0.26062101'
 authors = [{ name = 'Jeff Wheeler', email = 'jeffsw6@gmail.com' }]
 dependencies = [
     "boto3",

--- a/python/rpkilog/pyproject.toml
+++ b/python/rpkilog/pyproject.toml
@@ -9,6 +9,7 @@ authors = [{ name = 'Jeff Wheeler', email = 'jeffsw6@gmail.com' }]
 dependencies = [
     "boto3",
     "boto3-stubs~=1.43.14",
+    "botocore>=1.43.14",
     'netaddr',
     'opensearch-py',
     'psutil',

--- a/python/rpkilog/rpkilog/cleanup_policy.py
+++ b/python/rpkilog/rpkilog/cleanup_policy.py
@@ -1,0 +1,12 @@
+from enum import StrEnum
+
+
+class CleanupPolicy(StrEnum):
+    CLEANUP_ALWAYS = 'always'
+    """Always unlink the local cache on destroy/exit."""
+
+    CLEANUP_NEVER = 'never'
+    """Never unlink the local cache (e.g. pointing at an externally owned source file)."""
+
+    CLEANUP_IF_IN_S3 = 'if_in_s3'
+    """Unlink the local cache only when s3_stored is True (default)."""

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -12,6 +12,7 @@ import urllib.parse
 
 import boto3
 import dateutil.parser
+from botocore.exceptions import ClientError
 
 from rpkilog.local_storage_type import LocalStorageType
 
@@ -24,6 +25,14 @@ class DataFileSuper(ABC):
     and other things common to the different types of files we work with.
     """
     default_filename_strftime_expression: str
+    repr_attrs: list[str] = [
+        'datetimestamp',
+        'local_filepath_uncompressed',
+        'local_filepath_bz2',
+        'local_storage_type',
+        's3_url',
+        's3_stored',
+    ]
     # used by property getter/setter
     _default_s3_base_url: str = None
     default_local_storage_dir: Path = None
@@ -75,19 +84,19 @@ class DataFileSuper(ABC):
                 case LocalStorageType.BZIP2:
                     os.unlink(self.local_filepath_bz2)
                     self.local_storage_type = LocalStorageType.UNCACHED
+                case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
+                    pass
 
     def __repr__(self):
-        # TODO: move this to a classvar so it can be overridden
-        include_attrs = [
-            'datetimestamp',
-            'local_filepath_uncompressed',
-            'local_filepath_bz2',
-            'local_storage_type',
-            's3_url',
-            's3_stored',
-        ]
+        """
+        repr_attrs is a classvar listing the instance attribute names to include.  Subclasses can
+        override it to add, remove, or reorder fields — no need to override __repr__ itself:
+
+            class VrpDiffFile(DataFileSuper):
+                repr_attrs = DataFileSuper.repr_attrs + ['diff_count']
+        """
         brief_dict = {}
-        for aname in include_attrs:
+        for aname in self.repr_attrs:
             if avalue := getattr(self, aname, None):
                 brief_dict[aname] = avalue
         cname = self.__class__.__name__
@@ -99,7 +108,7 @@ class DataFileSuper(ABC):
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
                 pass
-            case LocalStorageType.UNCACHED:
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
                 raise ValueError(f'cannot compress when there is no locally-cached snapshot file: {self}')
             case LocalStorageType.BZIP2:
                 if self.warned_compress_invoked_on_already_compressed_snapshot < 1:
@@ -115,6 +124,7 @@ class DataFileSuper(ABC):
         self.local_storage_type = LocalStorageType.BZIP2
         os.unlink(self.local_filepath_uncompressed)
 
+    @property
     def default_filename(self) -> str:
         retstr = self.datetimestamp.strftime(self.default_filename_strftime_expression)
         return retstr
@@ -193,7 +203,7 @@ class DataFileSuper(ABC):
     def local_filepath_bz2(self) -> Path:
         if self._local_filepath_bz2:
             return self._local_filepath_bz2
-        retpath = Path(self.local_storage_dir, self.default_filename())
+        retpath = Path(self.local_storage_dir, self.default_filename + '.bz2')
         return retpath
 
     @local_filepath_bz2.setter
@@ -204,7 +214,7 @@ class DataFileSuper(ABC):
     def local_filepath_uncompressed(self) -> Path:
         if self._local_filepath_uncompressed:
             return self._local_filepath_uncompressed
-        retpath = Path(self.local_storage_dir, self.default_filename())
+        retpath = Path(self.local_storage_dir, self.default_filename)
         return retpath
 
     @local_filepath_uncompressed.setter
@@ -224,50 +234,75 @@ class DataFileSuper(ABC):
         self._local_storage_dir = value
 
     def open_for_read(self) -> IO[bytes] | IO[str]:
+        """
+        Kept as a method rather than a property because it returns an open file handle that the
+        caller must close — resource factories conventionally stay as methods.
+        """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
                 retfh = open(self.local_filepath_uncompressed)
             case LocalStorageType.BZIP2:
                 retfh = bz2.open(self.local_filepath_bz2, mode='rb')
-            case LocalStorageType.UNCACHED:
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
                 self.s3_download()
                 retfh = bz2.open(self.local_filepath_bz2, mode='rb')
             case _:
                 raise ValueError(f'unexpected value of local_storage_type: {self}')
         return retfh
 
+    @property
     def s3_bucket(self) -> str:
         url = urllib.parse.urlparse(self.s3_url)
         return url.netloc
 
     def s3_download(self):
-        bucket = boto3.resource('s3').Bucket(self.s3_bucket())
+        bucket = boto3.resource('s3').Bucket(self.s3_bucket)
         bucket.download_file(
-            key=self.s3_path,
-            filename=self.local_filepath_bz2,
+            Key=self.s3_path,
+            Filename=str(self.local_filepath_bz2),
         )
         self.local_storage_type = LocalStorageType.BZIP2
 
+    def s3_exists(self) -> bool:
+        """
+        Return True if the S3 object at self.s3_url already exists.
+
+        Kept as a method rather than a property because it makes a live network call — a property
+        that silently hits S3 on every attribute access would be surprising.
+        """
+        try:
+            boto3.client('s3').head_object(Bucket=self.s3_bucket, Key=self.s3_path)
+            retval = True
+        except ClientError as exc:
+            if exc.response['Error']['Code'] == '404':
+                retval = False
+            else:
+                raise
+        return retval
+
+    @property
     def s3_path(self) -> str:
         url = urllib.parse.urlparse(self.s3_url)
         retstr = url.path.lstrip('/')
         return retstr
 
     def s3_upload(self):
-        bucket = boto3.resource('s3').Bucket(self.s3_bucket())
+        bucket = boto3.resource('s3').Bucket(self.s3_bucket)
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
                 uncomp_fh = open(self.local_filepath_uncompressed, 'rb')
                 data_uncompressed = uncomp_fh.read()
                 uncomp_fh.close()
                 data_bz2 = bz2.compress(data_uncompressed)
-                s3_object = bucket.put_object(Key=self.s3_path(), Body=data_bz2)
+                s3_object = bucket.put_object(Key=self.s3_path, Body=data_bz2)
             case LocalStorageType.BZIP2:
                 bz2_fh = open(self.local_filepath_bz2, 'rb')
-                s3_object = bucket.put_object(Key=self.s3_path(), Body=bz2_fh)
-            case _:
+                s3_object = bucket.put_object(Key=self.s3_path, Body=bz2_fh)
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
                 raise ValueError(f'cannot upload without a local file to upload from: {self}')
-        self.s3_url = f's3://{self.s3_bucket()}/{self.s3_path()}'
+            case _:
+                raise ValueError(f'unexpected value of local_storage_type: {self}')
+        self.s3_url = f's3://{self.s3_bucket}/{self.s3_path}'
         logger.info(f'uploaded {self.s3_url}')
         self.cleanup_upon_destroy = True
         return s3_object
@@ -283,11 +318,35 @@ class DataFileSuper(ABC):
             _ = urllib.parse.urlparse(value)
         self._s3_url = value
 
-    def s3_url_default(self):
-        # set and return the default s3_url based on filename & '.bz2' suffix
-        retstr = self.default_s3_base_url_get() + str(self.default_filename()) + '.bz2'
+    def s3_url_set_to_default(self):
+        """
+        Set self.s3_url to the default value derived from default_s3_base_url and default_filename,
+        then return it.
+
+        Kept as a method rather than a property because it has the side effect of mutating self.s3_url.
+        """
+        retstr = self.default_s3_base_url_get() + str(self.default_filename) + '.bz2'
         self.s3_url = retstr
         return retstr
+
+    def write_json(self, data: dict | list):
+        """Write data as JSON to self.local_filepath_uncompressed and update local_storage_type."""
+        with open(self.local_filepath_uncompressed, 'wt') as fh:
+            json.dump(data, fh)
+        self.local_storage_type = LocalStorageType.UNCOMPRESSED
+
+    def write_to_path(self, dest: Path):
+        """Copy the locally-cached file to dest, downloading from S3 first if UNCACHED."""
+        match self.local_storage_type:
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
+                self.s3_download()
+                shutil.copy2(self.local_filepath_bz2, dest)
+            case LocalStorageType.BZIP2:
+                shutil.copy2(self.local_filepath_bz2, dest)
+            case LocalStorageType.UNCOMPRESSED:
+                shutil.copy2(self.local_filepath_uncompressed, dest)
+            case _:
+                raise ValueError(f'unexpected value of local_storage_type: {self}')
 
     def unlink_cached(self):
         """

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -23,6 +23,26 @@ class DataFileSuper(ABC):
     """
     Superclass for RoutinatorSnapshotFile, SummaryFile, and others.  This helps with bzipping, S3 uploads,
     and other things common to the different types of files we work with.
+
+    TODO: s3_stored is declared in __init__ and appears in repr_attrs, but s3_upload() never sets
+     self.s3_stored = True.  Either set it there or remove the attribute entirely.
+
+    TODO: default_filename_strftime_expression is a bare annotation with no default and no enforcement.
+     A subclass that omits it gets AttributeError deep inside the default_filename property rather than
+     a helpful error at class-definition time.  Consider an __init_subclass__ check, e.g.:
+       def __init_subclass__(cls, **kwargs):
+           super().__init_subclass__(**kwargs)
+           if not hasattr(cls, 'default_filename_strftime_expression'):
+               raise TypeError(f'{cls.__name__} must define default_filename_strftime_expression')
+
+    TODO: The warned_* counters are class-level ints.  In Python, self.x += 1 on a class-level int
+     creates a new instance attribute on first write, so they do work per-instance — but the pattern
+     is confusing to readers who expect class-level state to be shared.  Consider moving them to
+     __init__ as self.warned_... = 0 for clarity.
+
+    TODO: warned_default_local_storage_dir_unconfigured is declared but never referenced anywhere in
+     the codebase.  It was presumably intended for a warning path in local_storage_dir, which raises
+     instead.  Remove it or implement the warning it was meant for.
     """
     default_filename_strftime_expression: str
     repr_attrs: list[str] = [
@@ -173,6 +193,13 @@ class DataFileSuper(ABC):
         Raise an exception if neither are successful (type of exception depends on how json.load() fails)
 
         Update self.local_storage_type and self.local_filepath_uncompressed or self.local_filepath_bz2.
+
+        TODO: Both branches open a file handle with fh.close() rather than a with statement.  If
+         json.load(fh) raises (e.g. corrupt file, valid bz2 but invalid JSON), the handle leaks.
+         Fix: wrap both opens in with blocks.
+
+        TODO: Both branches parse the entire JSON just to confirm the file is readable.  Checking only
+         the first few bytes for the bz2 magic (\x42\x5a\x68) would be far cheaper for large files.
         """
         try:
             fh = bz2.open(filename=path, mode='r')
@@ -194,6 +221,10 @@ class DataFileSuper(ABC):
 
     @property
     def json_data_cache(self):
+        """
+        TODO: open_for_read() returns a file handle that is never closed here.  json.load(fh)
+         reads from it and then it is abandoned until GC.  Fix: with self.open_for_read() as fh:
+        """
         if not self._json_data_cache:
             fh = self.open_for_read()
             self._json_data_cache = json.load(fh)
@@ -252,6 +283,10 @@ class DataFileSuper(ABC):
 
     @property
     def s3_bucket(self) -> str:
+        """
+        TODO: if s3_url is None, urllib.parse.urlparse(None) raises TypeError with no helpful context.
+         Add: if self.s3_url is None: raise ValueError('s3_url must be set before accessing s3_bucket')
+        """
         url = urllib.parse.urlparse(self.s3_url)
         return url.netloc
 
@@ -282,6 +317,10 @@ class DataFileSuper(ABC):
 
     @property
     def s3_path(self) -> str:
+        """
+        TODO: if s3_url is None, urllib.parse.urlparse(None) raises TypeError with no helpful context.
+         Add: if self.s3_url is None: raise ValueError('s3_url must be set before accessing s3_path')
+        """
         url = urllib.parse.urlparse(self.s3_url)
         retstr = url.path.lstrip('/')
         return retstr
@@ -296,6 +335,7 @@ class DataFileSuper(ABC):
                 data_bz2 = bz2.compress(data_uncompressed)
                 s3_object = bucket.put_object(Key=self.s3_path, Body=data_bz2)
             case LocalStorageType.BZIP2:
+                # TODO: bz2_fh is never explicitly closed; use a with block
                 bz2_fh = open(self.local_filepath_bz2, 'rb')
                 s3_object = bucket.put_object(Key=self.s3_path, Body=bz2_fh)
             case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
@@ -353,7 +393,8 @@ class DataFileSuper(ABC):
         If there is a locally-cached copy of the snapshot, unlink it.
         If there's already NOT a copy, log a warning (just once) but don't raise an exception.
 
-        I think self.cleanup_upon_destroy will make this method unnecessary.  Maybe remove it.
+        TODO: cleanup_upon_destroy already handles deletion on GC.  Evaluate whether this method
+         is still needed at any call site, and remove it if not.
         """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -14,6 +14,7 @@ import boto3
 import dateutil.parser
 from botocore.exceptions import ClientError
 
+from rpkilog.cleanup_policy import CleanupPolicy
 from rpkilog.local_storage_type import LocalStorageType
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class DataFileSuper(ABC):
     def __init__(
             self,
             datetimestamp: datetime,
-            cleanup_upon_destroy: bool = False,
+            cleanup_policy: CleanupPolicy = CleanupPolicy.CLEANUP_IF_IN_S3,
             local_filepath_uncompressed: Path = None,
             local_filepath_bz2: Path = None,
             local_storage_dir: Path = None,
@@ -66,7 +67,7 @@ class DataFileSuper(ABC):
             s3_stored: bool = False,
     ):
         self.datetimestamp = datetimestamp
-        self.cleanup_upon_destroy = cleanup_upon_destroy
+        self.cleanup_policy = cleanup_policy
         self.local_filepath_bz2 = local_filepath_bz2
         self.local_filepath_uncompressed = local_filepath_uncompressed
         self.local_storage_type = local_storage_type
@@ -77,17 +78,17 @@ class DataFileSuper(ABC):
 
     def __del__(self):
         """
-        Clean up cached files on disk when destructor invoked AND self.cleanup_upon_destroy == True.
+        Clean up cached files on disk when the destructor runs AND self.cleanup_policy permits it
+        (see _should_cleanup()).
 
-        Generally, self.cleanup_upon_destroy will be set true if a snapshot is uploaded to S3.  A caller
-        could override that by setting it back to false after an upload.
-
-        Caller can also manually set it to True.  Maybe they want this after summarization.
+        Under the default CLEANUP_IF_IN_S3 policy, cleanup happens once the file has been uploaded
+        to S3.  A caller can force or suppress cleanup by setting self.cleanup_policy to
+        CLEANUP_ALWAYS or CLEANUP_NEVER.
 
         This destructor is retained as a fallback for instances not used in a `with` block.  When
         deterministic cleanup is desired, prefer the context manager (__enter__/__exit__) instead.
         """
-        if self.cleanup_upon_destroy:
+        if self._should_cleanup():
             self._cleanup_local_cache()
 
     def __enter__(self):
@@ -95,18 +96,36 @@ class DataFileSuper(ABC):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
-        Clean up the local cached file on context exit when self.cleanup_upon_destroy == True
-        (s3_upload() sets it True after a successful upload).  Returns False so any in-flight
-        exception is never suppressed.  __del__ remains a fallback for non-`with` usage.
+        Clean up the local cached file on context exit when self.cleanup_policy permits it (see
+        _should_cleanup()).  Under the default CLEANUP_IF_IN_S3 policy, s3_upload() sets s3_stored
+        True so cleanup happens after a successful upload.  Returns False so any in-flight exception
+        is never suppressed.  __del__ remains a fallback for non-`with` usage.
         """
-        if self.cleanup_upon_destroy:
+        if self._should_cleanup():
             self._cleanup_local_cache()
         return False
+
+    def _should_cleanup(self) -> bool:
+        """
+        Decide whether the locally-cached file should be unlinked on destroy/exit, per
+        self.cleanup_policy.  CLEANUP_ALWAYS always cleans up, CLEANUP_NEVER never does, and
+        CLEANUP_IF_IN_S3 cleans up only once the file is stored in S3.
+        """
+        match self.cleanup_policy:
+            case CleanupPolicy.CLEANUP_ALWAYS:
+                retval = True
+            case CleanupPolicy.CLEANUP_NEVER:
+                retval = False
+            case CleanupPolicy.CLEANUP_IF_IN_S3:
+                retval = self.s3_stored
+            case _:
+                raise ValueError(f'unexpected value of cleanup_policy: {self}')
+        return retval
 
     def _cleanup_local_cache(self):
         """
         Unlink the locally-cached file (if any) and mark storage as UNCACHED.  Shared by __del__
-        and __exit__; callers gate on self.cleanup_upon_destroy.
+        and __exit__; callers gate on _should_cleanup().
         """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
@@ -342,7 +361,8 @@ class DataFileSuper(ABC):
         self.s3_stored = True
         self.s3_url = f's3://{self.s3_bucket}/{self.s3_path}'
         logger.info(f'uploaded {self.s3_url}')
-        self.cleanup_upon_destroy = True
+        # s3_stored is now True; under the default CLEANUP_IF_IN_S3 policy the local cache will be
+        # unlinked on destroy/exit, while CLEANUP_NEVER leaves an externally owned source file alone.
         return s3_object
 
     @property

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -23,26 +23,6 @@ class DataFileSuper(ABC):
     """
     Superclass for RoutinatorSnapshotFile, SummaryFile, and others.  This helps with bzipping, S3 uploads,
     and other things common to the different types of files we work with.
-
-    TODO: s3_stored is declared in __init__ and appears in repr_attrs, but s3_upload() never sets
-     self.s3_stored = True.  Either set it there or remove the attribute entirely.
-
-    TODO: default_filename_strftime_expression is a bare annotation with no default and no enforcement.
-     A subclass that omits it gets AttributeError deep inside the default_filename property rather than
-     a helpful error at class-definition time.  Consider an __init_subclass__ check, e.g.:
-       def __init_subclass__(cls, **kwargs):
-           super().__init_subclass__(**kwargs)
-           if not hasattr(cls, 'default_filename_strftime_expression'):
-               raise TypeError(f'{cls.__name__} must define default_filename_strftime_expression')
-
-    TODO: The warned_* counters are class-level ints.  In Python, self.x += 1 on a class-level int
-     creates a new instance attribute on first write, so they do work per-instance — but the pattern
-     is confusing to readers who expect class-level state to be shared.  Consider moving them to
-     __init__ as self.warned_... = 0 for clarity.
-
-    TODO: warned_default_local_storage_dir_unconfigured is declared but never referenced anywhere in
-     the codebase.  It was presumably intended for a warning path in local_storage_dir, which raises
-     instead.  Remove it or implement the warning it was meant for.
     """
     default_filename_strftime_expression: str
     repr_attrs: list[str] = [
@@ -58,9 +38,21 @@ class DataFileSuper(ABC):
     default_local_storage_dir: Path = None
     # warning deduplication so log won't get spammy about minor issues
     warned_compress_invoked_on_already_compressed_snapshot = 0
-    warned_default_local_storage_dir_unconfigured = 0
     warned_file_already_does_not_exist = 0
     warned_unlink_cached_none_found = 0
+
+    def __init_subclass__(cls, **kwargs):
+        """
+        Enforce at class-definition time that every concrete subclass defines
+        default_filename_strftime_expression.  Without this check, a subclass that omits it would
+        instead raise a confusing AttributeError deep inside the default_filename property.
+        """
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, 'default_filename_strftime_expression'):
+            raise TypeError(
+                f"{cls.__name__} must define default_filename_strftime_expression, "
+                f"e.g. '%Y%m%dT%H%M%SZ.filetype.json'"
+            )
 
     def __init__(
             self,
@@ -131,9 +123,9 @@ class DataFileSuper(ABC):
             case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
                 raise ValueError(f'cannot compress when there is no locally-cached snapshot file: {self}')
             case LocalStorageType.BZIP2:
-                if self.warned_compress_invoked_on_already_compressed_snapshot < 1:
+                if type(self).warned_compress_invoked_on_already_compressed_snapshot < 1:
                     logger.warning(f'compress invoked on already-compressed snapshot file: {self}')
-                self.warned_compress_invoked_on_already_compressed_snapshot += 1
+                type(self).warned_compress_invoked_on_already_compressed_snapshot += 1
                 return
             case _:
                 raise ValueError(f'unexpected value of local_storage_type: {self}')
@@ -342,6 +334,7 @@ class DataFileSuper(ABC):
                 raise ValueError(f'cannot upload without a local file to upload from: {self}')
             case _:
                 raise ValueError(f'unexpected value of local_storage_type: {self}')
+        self.s3_stored = True
         self.s3_url = f's3://{self.s3_bucket}/{self.s3_path}'
         logger.info(f'uploaded {self.s3_url}')
         self.cleanup_upon_destroy = True
@@ -402,20 +395,20 @@ class DataFileSuper(ABC):
                     os.unlink(self.local_filepath_uncompressed)
                     self.local_storage_type = LocalStorageType.UNCACHED
                 except FileNotFoundError:
-                    if self.warned_unlink_cached_none_found < 1:
+                    if type(self).warned_unlink_cached_none_found < 1:
                         logger.warning(f'file already does not exist (warning only once): {self}')
-                    self.warned_unlink_cached_none_found += 1
+                    type(self).warned_unlink_cached_none_found += 1
             case LocalStorageType.BZIP2:
                 try:
                     os.unlink(self.local_filepath_bz2)
                     self.local_storage_type = LocalStorageType.UNCACHED
                 except FileNotFoundError:
-                    if self.warned_unlink_cached_none_found < 1:
+                    if type(self).warned_unlink_cached_none_found < 1:
                         logger.warning(f'file already does not exist (warning only once): {self}')
-                        self.warned_unlink_cached_none_found += 1
+                    type(self).warned_unlink_cached_none_found += 1
             case LocalStorageType.UNCACHED:
-                if self.warned_file_already_does_not_exist < 1:
+                if type(self).warned_file_already_does_not_exist < 1:
                     logger.warning(f'file already does not exist (warning only once): {self}')
-                    self.warned_file_already_does_not_exist += 1
+                type(self).warned_file_already_does_not_exist += 1
             case _:
                 logger.warning(f'unexpected value of LocalStorageType: {self}')

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -34,7 +34,12 @@ class DataFileSuper(ABC):
         's3_url',
         's3_stored',
     ]
-    # used by property getter/setter
+    # Caller-supplied base URL (e.g. 's3://bucket/' or 's3://bucket/prefix/') used to derive a NEW
+    # object's s3_url once, via s3_url_set_to_default()/_ensure_s3_url().  This is process-global
+    # class state: fine for the one-shot uploader CLI and single-process pytest, but a footgun for a
+    # future long-lived multi-bucket process.  Note an object whose s3_url is already KNOWN (e.g.
+    # loaded from a future SQL files table) never consults this — s3_url/s3_path/s3_bucket depend
+    # solely on the stored URL.
     _default_s3_base_url: str = None
     default_local_storage_dir: Path = None
     # warning deduplication so log won't get spammy about minor issues
@@ -309,7 +314,21 @@ class DataFileSuper(ABC):
         url = urllib.parse.urlparse(self.s3_url)
         return url.netloc
 
+    def _ensure_s3_url(self):
+        """
+        Resolve this object's s3_url exactly once when it is not already known.
+
+        If s3_url is unset, derive it from the class default base URL plus default_filename (via
+        s3_url_set_to_default()) and store it.  Once known — including for an object constructed with
+        an explicit s3_url, e.g. a future SQL-loaded record — the stored URL is authoritative and the
+        base URL is never consulted again.  Gating S3 operations on this keeps s3_path/s3_bucket
+        dependent solely on the known URL.
+        """
+        if self._s3_url is None:
+            self.s3_url_set_to_default()
+
     def s3_download(self):
+        self._ensure_s3_url()
         bucket = boto3.resource('s3').Bucket(self.s3_bucket)
         bucket.download_file(
             Key=self.s3_path,
@@ -324,6 +343,7 @@ class DataFileSuper(ABC):
         Kept as a method rather than a property because it makes a live network call — a property
         that silently hits S3 on every attribute access would be surprising.
         """
+        self._ensure_s3_url()
         try:
             boto3.client('s3').head_object(Bucket=self.s3_bucket, Key=self.s3_path)
             retval = True
@@ -343,6 +363,7 @@ class DataFileSuper(ABC):
         return retstr
 
     def s3_upload(self):
+        self._ensure_s3_url()
         bucket = boto3.resource('s3').Bucket(self.s3_bucket)
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -84,20 +84,39 @@ class DataFileSuper(ABC):
 
         Caller can also manually set it to True.  Maybe they want this after summarization.
 
-        TODO: Consider adding context manager support to DataFileSuper and using for cleanup instead
-         of destructor.  Copilot PR review points out exceptions during destructor phase aren't ergonomic
-         and mutating external state in destructor may be surprising.
+        This destructor is retained as a fallback for instances not used in a `with` block.  When
+        deterministic cleanup is desired, prefer the context manager (__enter__/__exit__) instead.
         """
         if self.cleanup_upon_destroy:
-            match self.local_storage_type:
-                case LocalStorageType.UNCOMPRESSED:
-                    os.unlink(self.local_filepath_uncompressed)
-                    self.local_storage_type = LocalStorageType.UNCACHED
-                case LocalStorageType.BZIP2:
-                    os.unlink(self.local_filepath_bz2)
-                    self.local_storage_type = LocalStorageType.UNCACHED
-                case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
-                    pass
+            self._cleanup_local_cache()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Clean up the local cached file on context exit when self.cleanup_upon_destroy == True
+        (s3_upload() sets it True after a successful upload).  Returns False so any in-flight
+        exception is never suppressed.  __del__ remains a fallback for non-`with` usage.
+        """
+        if self.cleanup_upon_destroy:
+            self._cleanup_local_cache()
+        return False
+
+    def _cleanup_local_cache(self):
+        """
+        Unlink the locally-cached file (if any) and mark storage as UNCACHED.  Shared by __del__
+        and __exit__; callers gate on self.cleanup_upon_destroy.
+        """
+        match self.local_storage_type:
+            case LocalStorageType.UNCOMPRESSED:
+                os.unlink(self.local_filepath_uncompressed)
+                self.local_storage_type = LocalStorageType.UNCACHED
+            case LocalStorageType.BZIP2:
+                os.unlink(self.local_filepath_bz2)
+                self.local_storage_type = LocalStorageType.UNCACHED
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
+                pass
 
     def __repr__(self):
         """
@@ -186,17 +205,13 @@ class DataFileSuper(ABC):
 
         Update self.local_storage_type and self.local_filepath_uncompressed or self.local_filepath_bz2.
 
-        TODO: Both branches open a file handle with fh.close() rather than a with statement.  If
-         json.load(fh) raises (e.g. corrupt file, valid bz2 but invalid JSON), the handle leaks.
-         Fix: wrap both opens in with blocks.
-
-        TODO: Both branches parse the entire JSON just to confirm the file is readable.  Checking only
-         the first few bytes for the bz2 magic (\x42\x5a\x68) would be far cheaper for large files.
+        NOTE: Both branches parse the entire JSON just to confirm the file is readable.  Checking only
+        the first few bytes for the bz2 magic (\x42\x5a\x68) would be far cheaper for large files.  I've
+        kept the full JSON load as a verification step.
         """
         try:
-            fh = bz2.open(filename=path, mode='r')
-            _ = json.load(fh)
-            fh.close()
+            with bz2.open(filename=path, mode='r') as fh:
+                _ = json.load(fh)
             self.local_storage_type = LocalStorageType.BZIP2
             self.local_filepath_bz2 = path
             return self.local_storage_type
@@ -204,22 +219,17 @@ class DataFileSuper(ABC):
             # bz2 raises OSError when you open a non-bz2 file and try to read from it.
             pass
 
-        fh = open(file=path, mode='rt')
-        _ = json.load(fh)
-        fh.close()
+        with open(file=path, mode='rt') as fh:
+            _ = json.load(fh)
         self.local_storage_type = LocalStorageType.UNCOMPRESSED
         self.local_filepath_uncompressed = path
         return self.local_storage_type
 
     @property
     def json_data_cache(self):
-        """
-        TODO: open_for_read() returns a file handle that is never closed here.  json.load(fh)
-         reads from it and then it is abandoned until GC.  Fix: with self.open_for_read() as fh:
-        """
         if not self._json_data_cache:
-            fh = self.open_for_read()
-            self._json_data_cache = json.load(fh)
+            with self.open_for_read() as fh:
+                self._json_data_cache = json.load(fh)
         return self._json_data_cache
 
     @property
@@ -275,10 +285,8 @@ class DataFileSuper(ABC):
 
     @property
     def s3_bucket(self) -> str:
-        """
-        TODO: if s3_url is None, urllib.parse.urlparse(None) raises TypeError with no helpful context.
-         Add: if self.s3_url is None: raise ValueError('s3_url must be set before accessing s3_bucket')
-        """
+        if self.s3_url is None:
+            raise ValueError('s3_url must be set before accessing s3_bucket')
         url = urllib.parse.urlparse(self.s3_url)
         return url.netloc
 
@@ -309,10 +317,8 @@ class DataFileSuper(ABC):
 
     @property
     def s3_path(self) -> str:
-        """
-        TODO: if s3_url is None, urllib.parse.urlparse(None) raises TypeError with no helpful context.
-         Add: if self.s3_url is None: raise ValueError('s3_url must be set before accessing s3_path')
-        """
+        if self.s3_url is None:
+            raise ValueError('s3_url must be set before accessing s3_path')
         url = urllib.parse.urlparse(self.s3_url)
         retstr = url.path.lstrip('/')
         return retstr
@@ -327,9 +333,8 @@ class DataFileSuper(ABC):
                 data_bz2 = bz2.compress(data_uncompressed)
                 s3_object = bucket.put_object(Key=self.s3_path, Body=data_bz2)
             case LocalStorageType.BZIP2:
-                # TODO: bz2_fh is never explicitly closed; use a with block
-                bz2_fh = open(self.local_filepath_bz2, 'rb')
-                s3_object = bucket.put_object(Key=self.s3_path, Body=bz2_fh)
+                with open(self.local_filepath_bz2, 'rb') as bz2_fh:
+                    s3_object = bucket.put_object(Key=self.s3_path, Body=bz2_fh)
             case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
                 raise ValueError(f'cannot upload without a local file to upload from: {self}')
             case _:
@@ -385,9 +390,6 @@ class DataFileSuper(ABC):
         """
         If there is a locally-cached copy of the snapshot, unlink it.
         If there's already NOT a copy, log a warning (just once) but don't raise an exception.
-
-        TODO: cleanup_upon_destroy already handles deletion on GC.  Evaluate whether this method
-         is still needed at any call site, and remove it if not.
         """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -93,8 +93,13 @@ class DataFileSuper(ABC):
         This destructor is retained as a fallback for instances not used in a `with` block.  When
         deterministic cleanup is desired, prefer the context manager (__enter__/__exit__) instead.
         """
-        if self._should_cleanup():
-            self._cleanup_local_cache()
+        try:
+            if self._should_cleanup():
+                self._cleanup_local_cache()
+        except AttributeError:
+            # __del__ can run on a partially-initialized instance (__init__ raised before
+            # cleanup_policy was set); there is nothing cached to clean up.
+            pass
 
     def __enter__(self):
         return self
@@ -194,14 +199,16 @@ class DataFileSuper(ABC):
     @classmethod
     def default_s3_base_url_set(cls, value: Union[str, urllib.parse.ParseResult]):
         """
-        This setter exists purely to ensure the URL contains at least one '/' after the hostname/netloc.
-        For example, if you give it 'http://bucket' it will set the value to 'http://bucket/'.
+        Validate the 's3://' scheme and ensure the URL contains at least one '/' after the
+        hostname/netloc.  For example, given 's3://bucket' it stores 's3://bucket/'.
         """
         if isinstance(value, urllib.parse.ParseResult):
             # instead of deepcopy
             u1 = value
         else:
             u1 = urllib.parse.urlparse(str(value))
+        if u1.scheme != 's3':
+            raise ValueError(f"default s3 base URL must use the 's3://' scheme, got: {value!r}")
         s1 = urllib.parse.urlunparse(u1)
         if u1.path == '':
             cls._default_s3_base_url = s1 + '/'
@@ -393,8 +400,10 @@ class DataFileSuper(ABC):
     @s3_url.setter
     def s3_url(self, value: str | None):
         if value is not None:
-            # validate & allow exception to be raised if urlparse fails
-            _ = urllib.parse.urlparse(value)
+            # validate scheme; allow exception to be raised if urlparse fails
+            parsed = urllib.parse.urlparse(value)
+            if parsed.scheme != 's3':
+                raise ValueError(f"s3_url must use the 's3://' scheme, got: {value!r}")
         self._s3_url = value
 
     def s3_url_set_to_default(self):

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -18,23 +18,26 @@ from rpkilog.snapshot_summary_file import SnapshotSummaryFile
 logger = logging.getLogger(__name__)
 
 
-def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
+def s3_upload(rpkiclient_json: Path, s3_base_url: str) -> str | None:
     """
-    Given a Path to rpkiclient's output/json file, determine if it is already present in the given S3
-    bucket.  If not, bzip2 and upload it.  Filename format is YYYYMMDDTHHMMSSZ.json.bz2.
+    Given a Path to rpkiclient's output/json file, determine if it is already present under the given
+    S3 base URL.  If not, bzip2 and upload it.  Object key format is YYYYMMDDTHHMMSSZ.json.bz2.
+
+    The caller supplies the S3 base URL (e.g. 's3://bucket/' or 's3://bucket/prefix/'); we set it as
+    the class default and let SnapshotSummaryFile derive the object's URL from it plus the buildtime.
 
     CLEANUP_NEVER keeps us from deleting rpki-client's live source file, which we point at directly.
     """
     with open(rpkiclient_json, 'rt') as json_fh:
         json_data = json.load(json_fh)
     json_datetime = SnapshotSummaryFile.datetimestamp_from_json(json_data)
+    SnapshotSummaryFile.default_s3_base_url_set(s3_base_url)
     ssf = SnapshotSummaryFile(
         datetimestamp=json_datetime,
         local_filepath_uncompressed=rpkiclient_json,
         local_storage_type=LocalStorageType.UNCOMPRESSED,
         cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
     )
-    ssf.s3_url = f's3://{s3_bucket_name}/{ssf.default_filename}.bz2'
     if ssf.s3_exists():
         logger.info(f'Currently available rpkiclient json file {json_datetime} has already been uploaded.')
         return None
@@ -71,7 +74,8 @@ def cli_entry_point():
             f'System uptime {uptime:.0f}s is less than --minimum-uptime {args.minimum_uptime:.0f}s; skipping upload'
         )
         return
+    s3_base_url = f's3://{args.s3_snapshot_summary_bucket}/'
     s3_upload(
         rpkiclient_json=args.json_file_path,
-        s3_bucket_name=args.s3_snapshot_summary_bucket,
+        s3_base_url=s3_base_url,
     )

--- a/python/rpkilog/rpkilog/rpkiclient_uploader.py
+++ b/python/rpkilog/rpkilog/rpkiclient_uploader.py
@@ -1,62 +1,49 @@
 """
-This is being written in a bit of a rush to start sourcing snapshots from our own validator.
-There is opportunity for re-use being ignored here.
+Upload rpkiclient's output/json snapshot-summary file to S3, driving a SnapshotSummaryFile so the
+filename derivation, size validation, bzip2 compression, and S3 upload all live in one place.
 """
 import argparse
-import bz2
-from datetime import datetime, timezone, UTC
 import json
 import logging
 from pathlib import Path
 import time
 
-import boto3
-import dateutil.parser
 import psutil
+
+from rpkilog.cleanup_policy import CleanupPolicy
+from rpkilog.local_storage_type import LocalStorageType
+from rpkilog.snapshot_summary_file import SnapshotSummaryFile
 
 
 logger = logging.getLogger(__name__)
-MINIMUM_JSON_SIZE = 8_500_000
-
-
-def get_bz2_filename_from_datetime(dt: datetime) -> str:
-    retval = dt.strftime('%Y%m%dT%H%M%SZ.json.bz2')
-    return retval
-
-
-def get_rpkiclient_datetime_from_json(json_serialized: bytes | str) -> datetime:
-    json_data = json.loads(json_serialized)
-    retval = dateutil.parser.parse(json_data['metadata']['buildtime'])
-    return retval
 
 
 def s3_upload(rpkiclient_json: Path, s3_bucket_name: str) -> str | None:
     """
-    Given a Path to rpkiclient's output/json file, determine if it is already present in the given S3 bucket.
-    If not, bzip2 and upload it.  Filename format is YYYYMMDDTHHMMSSZ.json.bz2.
+    Given a Path to rpkiclient's output/json file, determine if it is already present in the given S3
+    bucket.  If not, bzip2 and upload it.  Filename format is YYYYMMDDTHHMMSSZ.json.bz2.
+
+    CLEANUP_NEVER keeps us from deleting rpki-client's live source file, which we point at directly.
     """
-    with open(rpkiclient_json, 'rb') as json_fh:
-        json_buffer = json_fh.read()
-    if len(json_buffer) < MINIMUM_JSON_SIZE:
-        raise RuntimeError(f'JSON file is too small to be reliable: {rpkiclient_json} < {MINIMUM_JSON_SIZE}')
-    json_datetime = get_rpkiclient_datetime_from_json(json_serialized=json_buffer)
-    bz2_filename = get_bz2_filename_from_datetime(json_datetime)
-    s3 = boto3.client('s3')
-    s3_list_result = s3.list_objects(
-        Bucket = s3_bucket_name,
-        Prefix = bz2_filename,
+    with open(rpkiclient_json, 'rt') as json_fh:
+        json_data = json.load(json_fh)
+    json_datetime = SnapshotSummaryFile.datetimestamp_from_json(json_data)
+    ssf = SnapshotSummaryFile(
+        datetimestamp=json_datetime,
+        local_filepath_uncompressed=rpkiclient_json,
+        local_storage_type=LocalStorageType.UNCOMPRESSED,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
     )
-    if len(s3_list_result.get('Contents', [])):
+    ssf.s3_url = f's3://{s3_bucket_name}/{ssf.default_filename}.bz2'
+    if ssf.s3_exists():
         logger.info(f'Currently available rpkiclient json file {json_datetime} has already been uploaded.')
         return None
-    logger.info(f'Preparing to upload {len(json_buffer)/1048576:.1f} MB by compressing to {bz2_filename}')
-    bz2_buffer = bz2.compress(json_buffer)
-    bucket = boto3.resource('s3').Bucket(s3_bucket_name)
-    logger.info(f'Uploading {bz2_filename} to {s3_bucket_name} uncompressed: {len(json_buffer)/1048576:.1f} MB'
-                f' compressed: {len(bz2_buffer)/1048576:.1f} MB')
-    s3_object = bucket.put_object(Key=bz2_filename, Body=bz2_buffer)
+    ssf.validate_size()
+    logger.info(f'Preparing to compress and upload {ssf.s3_url}')
+    s3_object = ssf.s3_upload()
     logger.info(f'Uploaded successfully: {s3_object}')
-    return s3_object.key
+    retstr = s3_object.key
+    return retstr
 
 
 def cli_entry_point():

--- a/python/rpkilog/rpkilog/snapshot_summary_file.py
+++ b/python/rpkilog/rpkilog/snapshot_summary_file.py
@@ -1,0 +1,47 @@
+import bz2
+from datetime import datetime, timezone
+import re
+
+import dateutil.parser
+
+from rpkilog.data_file_super import DataFileSuper
+from rpkilog.local_storage_type import LocalStorageType
+
+
+class SnapshotSummaryFile(DataFileSuper):
+    """
+    Represents an rpkiclient snapshot-summary file: YYYYMMDDTHHMMSSZ.json[.bz2]
+
+    These are produced by rpkilog-rpkiclient-uploader and stored in the snapshot-summary S3 bucket.
+    """
+    default_filename_strftime_expression = '%Y%m%dT%H%M%SZ.json'
+    MINIMUM_SIZE = 8_500_000
+
+    @classmethod
+    def infer_datetimestamp_from_path(cls, path) -> datetime:
+        """Extract datetime from a snapshot-summary filename; rejects diff filenames."""
+        rem = re.search(r'(?P<dt>\d{8}T\d{6}Z)\.json(\.bz2)?$', str(path.name))
+        if not rem:
+            raise ValueError(f'regex did not match a snapshot-summary filename in given path: {path}')
+        dt = dateutil.parser.parse(rem.group('dt'))
+        retval = dt.replace(tzinfo=timezone.utc)
+        return retval
+
+    @classmethod
+    def datetimestamp_from_json(cls, json_data: dict) -> datetime:
+        """Extract the buildtime datetime from rpkiclient metadata."""
+        retval = dateutil.parser.parse(json_data['metadata']['buildtime'])
+        return retval
+
+    def validate_size(self):
+        """Raise RuntimeError if the uncompressed data is below MINIMUM_SIZE bytes."""
+        match self.local_storage_type:
+            case LocalStorageType.UNCOMPRESSED:
+                size = self.local_filepath_uncompressed.stat().st_size
+            case LocalStorageType.BZIP2:
+                with bz2.open(self.local_filepath_bz2, 'rb') as fh:
+                    size = len(fh.read())
+            case _:
+                raise ValueError(f'cannot validate size without a locally-cached file: {self}')
+        if size < self.MINIMUM_SIZE:
+            raise RuntimeError(f'file too small ({size} bytes < {self.MINIMUM_SIZE}): {self}')

--- a/python/rpkilog/rpkilog/snapshot_summary_file.py
+++ b/python/rpkilog/rpkilog/snapshot_summary_file.py
@@ -15,6 +15,7 @@ class SnapshotSummaryFile(DataFileSuper):
     These are produced by rpkilog-rpkiclient-uploader and stored in the snapshot-summary S3 bucket.
     """
     default_filename_strftime_expression = '%Y%m%dT%H%M%SZ.json'
+    # minimum uncompressed byte size of a valid rpkiclient output JSON
     MINIMUM_SIZE = 8_500_000
 
     @classmethod
@@ -29,12 +30,24 @@ class SnapshotSummaryFile(DataFileSuper):
 
     @classmethod
     def datetimestamp_from_json(cls, json_data: dict) -> datetime:
-        """Extract the buildtime datetime from rpkiclient metadata."""
+        """
+        Extract the buildtime datetime from rpkiclient metadata.
+
+        TODO: dateutil.parser.parse() returns a naive datetime if the buildtime string has no
+         timezone indicator.  The base class always calls .replace(tzinfo=timezone.utc) after
+         parsing; add the same here for consistency and robustness against malformed input.
+        """
         retval = dateutil.parser.parse(json_data['metadata']['buildtime'])
         return retval
 
     def validate_size(self):
-        """Raise RuntimeError if the uncompressed data is below MINIMUM_SIZE bytes."""
+        """
+        Raise RuntimeError if the uncompressed data is below MINIMUM_SIZE bytes.
+
+        TODO: The BZIP2 branch decompresses the entire file into memory just to count bytes.
+         For large files a streaming count avoids the memory spike:
+           size = sum(len(chunk) for chunk in iter(lambda: fh.read(65536), b''))
+        """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
                 size = self.local_filepath_uncompressed.stat().st_size

--- a/python/rpkilog/rpkilog/snapshot_summary_file.py
+++ b/python/rpkilog/rpkilog/snapshot_summary_file.py
@@ -33,27 +33,32 @@ class SnapshotSummaryFile(DataFileSuper):
         """
         Extract the buildtime datetime from rpkiclient metadata.
 
-        TODO: dateutil.parser.parse() returns a naive datetime if the buildtime string has no
-         timezone indicator.  The base class always calls .replace(tzinfo=timezone.utc) after
-         parsing; add the same here for consistency and robustness against malformed input.
+        dateutil.parser.parse() returns a naive datetime if the buildtime string has no timezone
+        indicator.  Like the base class, we call .replace(tzinfo=timezone.utc) after parsing for
+        consistency and robustness against malformed input.
         """
-        retval = dateutil.parser.parse(json_data['metadata']['buildtime'])
+        dt = dateutil.parser.parse(json_data['metadata']['buildtime'])
+        retval = dt.replace(tzinfo=timezone.utc)
         return retval
 
     def validate_size(self):
         """
         Raise RuntimeError if the uncompressed data is below MINIMUM_SIZE bytes.
 
-        TODO: The BZIP2 branch decompresses the entire file into memory just to count bytes.
-         For large files a streaming count avoids the memory spike:
-           size = sum(len(chunk) for chunk in iter(lambda: fh.read(65536), b''))
+        The BZIP2 branch streams the decompressed bytes in 256 KiB chunks and counts them rather
+        than reading the whole file into memory, avoiding a memory spike on large files.
         """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
                 size = self.local_filepath_uncompressed.stat().st_size
             case LocalStorageType.BZIP2:
+                size = 0
                 with bz2.open(self.local_filepath_bz2, 'rb') as fh:
-                    size = len(fh.read())
+                    while True:
+                        chunk = fh.read(256 * 1024)
+                        if not chunk:
+                            break
+                        size += len(chunk)
             case _:
                 raise ValueError(f'cannot validate size without a locally-cached file: {self}')
         if size < self.MINIMUM_SIZE:

--- a/python/rpkilog/rpkilog/snapshot_summary_file.py
+++ b/python/rpkilog/rpkilog/snapshot_summary_file.py
@@ -21,7 +21,7 @@ class SnapshotSummaryFile(DataFileSuper):
     @classmethod
     def infer_datetimestamp_from_path(cls, path) -> datetime:
         """Extract datetime from a snapshot-summary filename; rejects diff filenames."""
-        rem = re.search(r'(?P<dt>\d{8}T\d{6}Z)\.json(\.bz2)?$', str(path.name))
+        rem = re.search(r'(?P<dt>\d{8}T\d{4,6}Z)\.json(\.bz2)?$', str(path.name))
         if not rem:
             raise ValueError(f'regex did not match a snapshot-summary filename in given path: {path}')
         dt = dateutil.parser.parse(rem.group('dt'))

--- a/python/rpkilog/rpkilog/vrp_diff_file.py
+++ b/python/rpkilog/rpkilog/vrp_diff_file.py
@@ -26,7 +26,14 @@ class VrpDiffFile(DataFileSuper):
 
     @classmethod
     def from_summary_filename(cls, summary_filename: str, **kwargs) -> 'VrpDiffFile':
-        """Construct a VrpDiffFile with datetimestamp derived from a snapshot-summary filename."""
+        """
+        Construct a VrpDiffFile with datetimestamp derived from a snapshot-summary filename.
+
+        TODO: The regex uses [0-9]{4,6} for the time component, but SnapshotSummaryFile filenames
+         always use exactly 6 digits (HHMMSS).  The loose pattern silently accepts 4- or 5-digit
+         times.  Consider tightening to [0-9]{6} to match the summary class, or add a note here if
+         the looser match is intentional for legacy filename compatibility.
+        """
         rem = re.search(r'(?P<dt>\d{8}T\d{4,6}Z)\.json(\.bz2)?$', str(summary_filename))
         if not rem:
             raise ValueError(

--- a/python/rpkilog/rpkilog/vrp_diff_file.py
+++ b/python/rpkilog/rpkilog/vrp_diff_file.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+import re
+
+import dateutil.parser
+
+from rpkilog.data_file_super import DataFileSuper
+
+
+class VrpDiffFile(DataFileSuper):
+    """
+    Represents a VRP diff file: YYYYMMDDTHHMMSSZ.vrpdiff.json[.bz2]
+
+    These are produced by rpkilog-diff and stored in the vrpdiff S3 bucket.
+    """
+    default_filename_strftime_expression = '%Y%m%dT%H%M%SZ.vrpdiff.json'
+
+    @classmethod
+    def infer_datetimestamp_from_path(cls, path) -> datetime:
+        """Extract datetime from a vrpdiff filename; rejects summary filenames."""
+        rem = re.search(r'(?P<dt>\d{8}T\d{4,6}Z)\.vrpdiff\.json(\.bz2)?$', str(path.name))
+        if not rem:
+            raise ValueError(f'regex did not match a vrpdiff filename in given path: {path}')
+        dt = dateutil.parser.parse(rem.group('dt'))
+        retval = dt.replace(tzinfo=timezone.utc)
+        return retval
+
+    @classmethod
+    def from_summary_filename(cls, summary_filename: str, **kwargs) -> 'VrpDiffFile':
+        """Construct a VrpDiffFile with datetimestamp derived from a snapshot-summary filename."""
+        rem = re.search(r'(?P<dt>\d{8}T\d{4,6}Z)\.json(\.bz2)?$', str(summary_filename))
+        if not rem:
+            raise ValueError(
+                f'input does not match snapshot-summary filename pattern: {summary_filename!r}'
+            )
+        dt = dateutil.parser.parse(rem.group('dt'))
+        retval = cls(datetimestamp=dt.replace(tzinfo=timezone.utc), **kwargs)
+        return retval

--- a/python/rpkilog/rpkilog/vrp_diff_file.py
+++ b/python/rpkilog/rpkilog/vrp_diff_file.py
@@ -25,14 +25,13 @@ class VrpDiffFile(DataFileSuper):
         return retval
 
     @classmethod
-    def from_summary_filename(cls, summary_filename: str, **kwargs) -> 'VrpDiffFile':
+    def from_filename(cls, summary_filename: str, **kwargs) -> 'VrpDiffFile':
         """
         Construct a VrpDiffFile with datetimestamp derived from a snapshot-summary filename.
 
-        TODO: The regex uses [0-9]{4,6} for the time component, but SnapshotSummaryFile filenames
-         always use exactly 6 digits (HHMMSS).  The loose pattern silently accepts 4- or 5-digit
-         times.  Consider tightening to [0-9]{6} to match the summary class, or add a note here if
-         the looser match is intentional for legacy filename compatibility.
+        The time component uses the loose \\d{4,6} match for consistency with
+        infer_datetimestamp_from_path (above) and SnapshotSummaryFile.infer_datetimestamp_from_path,
+        tolerating 4- to 6-digit times in legacy filenames.
         """
         rem = re.search(r'(?P<dt>\d{8}T\d{4,6}Z)\.json(\.bz2)?$', str(summary_filename))
         if not rem:

--- a/python/rpkilog/tests/conftest.py
+++ b/python/rpkilog/tests/conftest.py
@@ -1,0 +1,45 @@
+"""
+Shared fixtures for rpkilog tests.
+"""
+import os
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+
+@pytest.fixture(scope='module')
+def s3_test_bucket():
+    """
+    Yields a boto3 Bucket resource pointed at the rpkilog test bucket.
+
+    Bucket name comes from RPKILOG_TEST_S3_BUCKET env var, or is auto-computed as
+    rpkilog-test-{account_id}-{region}-an.  The bucket is created if it does not exist.
+    """
+    s3_client = boto3.client('s3')
+    region = s3_client.meta.region_name
+
+    bucket_name = os.environ.get('RPKILOG_TEST_S3_BUCKET')
+    if not bucket_name:
+        account_id = boto3.client('sts').get_caller_identity()['Account']
+        bucket_name = f'rpkilog-test-{account_id}-{region}-an'
+
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+
+    try:
+        s3_client.head_bucket(Bucket=bucket_name)
+    except ClientError as exc:
+        code = exc.response['Error']['Code']
+        if code in ('404', 'NoSuchBucket'):
+            create_bucket_configuration: dict = {}
+            if region != 'us-east-1':
+                create_bucket_configuration['LocationConstraint'] = region
+            bucket.create(
+                CreateBucketConfiguration=create_bucket_configuration,
+                BucketNamespace='account-regional' if bucket_name.endswith('-an') else 'global',
+            )
+        else:
+            raise
+
+    yield bucket

--- a/python/rpkilog/tests/conftest.py
+++ b/python/rpkilog/tests/conftest.py
@@ -2,6 +2,7 @@
 Shared fixtures for rpkilog tests.
 """
 import os
+import uuid
 
 import boto3
 import pytest
@@ -43,3 +44,37 @@ def s3_test_bucket():
             raise
 
     yield bucket
+
+
+@pytest.fixture(scope='session')
+def s3_run_id():
+    """
+    A per-test-process identifier used to namespace S3 objects so concurrent CI matrix jobs (which
+    share one bucket) never collide on the same key.  Includes GITHUB_RUN_ID when present so any
+    leaked objects are traceable back to the run that created them.
+    """
+    run = os.environ.get('GITHUB_RUN_ID', 'local')
+    retstr = f'{run}-{uuid.uuid4().hex}'
+    return retstr
+
+
+@pytest.fixture
+def s3_base_url_factory(s3_test_bucket, s3_run_id):
+    """
+    Yields a callable set_base_url(cls, namespace) -> str that points a DataFileSuper subclass at a
+    run-unique S3 base URL of the form s3://{bucket}/citest/{run_id}/{namespace}/ and returns it.
+    The subclass then derives object URLs from that base.  Each subclass's prior class default is
+    restored on teardown so the process-global classvar does not leak between tests.
+    """
+    originals = []
+
+    def set_base_url(cls, namespace):
+        originals.append((cls, cls._default_s3_base_url))
+        base_url = f's3://{s3_test_bucket.name}/citest/{s3_run_id}/{namespace}/'
+        cls.default_s3_base_url_set(base_url)
+        return base_url
+
+    yield set_base_url
+
+    for cls, prev in originals:
+        cls._default_s3_base_url = prev

--- a/python/rpkilog/tests/test_rpkiclient_uploader.py
+++ b/python/rpkilog/tests/test_rpkiclient_uploader.py
@@ -3,6 +3,7 @@ import json
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -41,8 +42,10 @@ def test_datetimestamp_from_json_matches_legacy():
 def test_s3_upload_skips_when_object_exists(tmp_path, monkeypatch):
     source = tmp_path / 'json'
     _write_sample_json(source)
+    # isolate the process-global base-url classvar the uploader sets (auto-restored on teardown)
+    monkeypatch.setattr(SnapshotSummaryFile, '_default_s3_base_url', None, raising=False)
     monkeypatch.setattr(SnapshotSummaryFile, 's3_exists', lambda self: True)
-    result = rpkiclient_uploader.s3_upload(rpkiclient_json=source, s3_bucket_name='example-bucket')
+    result = rpkiclient_uploader.s3_upload(rpkiclient_json=source, s3_base_url='s3://example-bucket/')
     assert result is None
     assert source.exists()
 
@@ -54,11 +57,13 @@ def test_s3_upload_preserves_source_file(tmp_path, monkeypatch):
     class _FakeS3Object:
         key = GOLDEN_KEY
 
+    # isolate the process-global base-url classvar the uploader sets (auto-restored on teardown)
+    monkeypatch.setattr(SnapshotSummaryFile, '_default_s3_base_url', None, raising=False)
     monkeypatch.setattr(SnapshotSummaryFile, 's3_exists', lambda self: False)
     # skip the real size gate; the sample file is far below MINIMUM_SIZE
     monkeypatch.setattr(SnapshotSummaryFile, 'validate_size', lambda self: None)
     monkeypatch.setattr(SnapshotSummaryFile, 's3_upload', lambda self: _FakeS3Object())
-    result = rpkiclient_uploader.s3_upload(rpkiclient_json=source, s3_bucket_name='example-bucket')
+    result = rpkiclient_uploader.s3_upload(rpkiclient_json=source, s3_base_url='s3://example-bucket/')
     assert result == GOLDEN_KEY
     # CLEANUP_NEVER must leave rpki-client's live source file in place
     assert source.exists()
@@ -67,26 +72,27 @@ def test_s3_upload_preserves_source_file(tmp_path, monkeypatch):
 # --- S3 tests (require live AWS credentials) ---
 
 @pytest.mark.slow
-def test_s3_upload_end_to_end(tmp_path, s3_test_bucket):
+def test_s3_upload_end_to_end(tmp_path, s3_test_bucket, s3_base_url_factory):
     # decompress the golden summary into an uncompressed source file, mimicking output/json
     source = tmp_path / 'json'
     with bz2.open(GOLDEN_SUMMARY, 'rb') as src_fh:
         with open(source, 'wb') as dst_fh:
             shutil.copyfileobj(src_fh, dst_fh, length=1024 * 1024)
 
-    # the key derives from the JSON's metadata.buildtime, which differs from the filename's
+    # run-unique base URL so concurrent CI jobs don't collide on the bucket-derived key
+    base_url = s3_base_url_factory(SnapshotSummaryFile, 'test_rpkiclient_uploader')
+    # the key derives from base URL + metadata.buildtime, which differs from the filename's
     # timestamp in the golden data, so compute it the same way the uploader does
     with open(source, 'rt') as fh:
         json_data = json.load(fh)
     expected_dt = SnapshotSummaryFile.datetimestamp_from_json(json_data)
-    expected_key = expected_dt.strftime('%Y%m%dT%H%M%SZ.json.bz2')
+    expected_filename = expected_dt.strftime('%Y%m%dT%H%M%SZ.json') + '.bz2'
+    expected_key = urlparse(base_url).path.lstrip('/') + expected_filename
 
-    # ensure a clean slate so s3_exists() doesn't short-circuit the upload
-    s3_test_bucket.Object(expected_key).delete()
     try:
         result = rpkiclient_uploader.s3_upload(
             rpkiclient_json=source,
-            s3_bucket_name=s3_test_bucket.name,
+            s3_base_url=base_url,
         )
         assert result == expected_key
         # object landed in S3 (load() raises if it does not exist)

--- a/python/rpkilog/tests/test_rpkiclient_uploader.py
+++ b/python/rpkilog/tests/test_rpkiclient_uploader.py
@@ -1,0 +1,97 @@
+import bz2
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from rpkilog import rpkiclient_uploader
+from rpkilog.snapshot_summary_file import SnapshotSummaryFile
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent.parent / 'test_data'
+GOLDEN_SUMMARY = TEST_DATA_DIR / 'rpkiclient_summary_20250720T100145Z.json.bz2'
+GOLDEN_DT = datetime(2025, 7, 20, 10, 1, 45, tzinfo=timezone.utc)
+GOLDEN_KEY = '20250720T100145Z.json.bz2'
+
+
+def _write_sample_json(path: Path, buildtime: str = '2025-07-20T10:01:45Z') -> dict:
+    sample_data = {'metadata': {'buildtime': buildtime}, 'roas': []}
+    with open(path, 'wt') as fh:
+        json.dump(sample_data, fh)
+    return sample_data
+
+
+# --- Unit tests (no disk I/O beyond tmp_path, no S3) ---
+
+def test_filename_matches_legacy_format():
+    # legacy uploader derived the key as dt.strftime('%Y%m%dT%H%M%SZ.json.bz2')
+    ssf = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    legacy = GOLDEN_DT.strftime('%Y%m%dT%H%M%SZ.json.bz2')
+    assert ssf.default_filename + '.bz2' == legacy
+    assert ssf.default_filename + '.bz2' == GOLDEN_KEY
+
+
+def test_datetimestamp_from_json_matches_legacy():
+    json_data = {'metadata': {'buildtime': '2025-07-20T10:01:45Z'}}
+    dt = SnapshotSummaryFile.datetimestamp_from_json(json_data)
+    assert dt == GOLDEN_DT
+
+
+def test_s3_upload_skips_when_object_exists(tmp_path, monkeypatch):
+    source = tmp_path / 'json'
+    _write_sample_json(source)
+    monkeypatch.setattr(SnapshotSummaryFile, 's3_exists', lambda self: True)
+    result = rpkiclient_uploader.s3_upload(rpkiclient_json=source, s3_bucket_name='example-bucket')
+    assert result is None
+    assert source.exists()
+
+
+def test_s3_upload_preserves_source_file(tmp_path, monkeypatch):
+    source = tmp_path / 'json'
+    _write_sample_json(source)
+
+    class _FakeS3Object:
+        key = GOLDEN_KEY
+
+    monkeypatch.setattr(SnapshotSummaryFile, 's3_exists', lambda self: False)
+    # skip the real size gate; the sample file is far below MINIMUM_SIZE
+    monkeypatch.setattr(SnapshotSummaryFile, 'validate_size', lambda self: None)
+    monkeypatch.setattr(SnapshotSummaryFile, 's3_upload', lambda self: _FakeS3Object())
+    result = rpkiclient_uploader.s3_upload(rpkiclient_json=source, s3_bucket_name='example-bucket')
+    assert result == GOLDEN_KEY
+    # CLEANUP_NEVER must leave rpki-client's live source file in place
+    assert source.exists()
+
+
+# --- S3 tests (require live AWS credentials) ---
+
+@pytest.mark.slow
+def test_s3_upload_end_to_end(tmp_path, s3_test_bucket):
+    # decompress the golden summary into an uncompressed source file, mimicking output/json
+    source = tmp_path / 'json'
+    with bz2.open(GOLDEN_SUMMARY, 'rb') as src_fh:
+        with open(source, 'wb') as dst_fh:
+            shutil.copyfileobj(src_fh, dst_fh, length=1024 * 1024)
+
+    # the key derives from the JSON's metadata.buildtime, which differs from the filename's
+    # timestamp in the golden data, so compute it the same way the uploader does
+    with open(source, 'rt') as fh:
+        json_data = json.load(fh)
+    expected_dt = SnapshotSummaryFile.datetimestamp_from_json(json_data)
+    expected_key = expected_dt.strftime('%Y%m%dT%H%M%SZ.json.bz2')
+
+    # ensure a clean slate so s3_exists() doesn't short-circuit the upload
+    s3_test_bucket.Object(expected_key).delete()
+    try:
+        result = rpkiclient_uploader.s3_upload(
+            rpkiclient_json=source,
+            s3_bucket_name=s3_test_bucket.name,
+        )
+        assert result == expected_key
+        # object landed in S3 (load() raises if it does not exist)
+        s3_test_bucket.Object(expected_key).load()
+        # the local source copy is preserved (CLEANUP_NEVER)
+        assert source.exists()
+    finally:
+        s3_test_bucket.Object(expected_key).delete()

--- a/python/rpkilog/tests/test_snapshot_summary_file.py
+++ b/python/rpkilog/tests/test_snapshot_summary_file.py
@@ -1,0 +1,159 @@
+import bz2
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from rpkilog.local_storage_type import LocalStorageType
+from rpkilog.snapshot_summary_file import SnapshotSummaryFile
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent.parent / 'test_data'
+GOLDEN_SUMMARY = TEST_DATA_DIR / 'rpkiclient_summary_20250720T100145Z.json.bz2'
+GOLDEN_DT = datetime(2025, 7, 20, 10, 1, 45, tzinfo=timezone.utc)
+
+
+# --- Unit tests (no disk I/O, no S3) ---
+
+def test_filename_generation():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert f.default_filename == '20250720T100145Z.json'
+
+
+def test_local_filepath_bz2_appends_extension():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert str(f.local_filepath_bz2).endswith('.json.bz2')
+    assert not str(f.local_filepath_bz2).endswith('.json.bz2.bz2')
+
+
+def test_local_filepath_uncompressed_no_bz2_suffix():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert str(f.local_filepath_uncompressed).endswith('.json')
+    assert not str(f.local_filepath_uncompressed).endswith('.bz2')
+
+
+def test_infer_datetimestamp_from_path_plain():
+    p = Path('20250720T100145Z.json')
+    dt = SnapshotSummaryFile.infer_datetimestamp_from_path(p)
+    assert dt == GOLDEN_DT
+
+
+def test_infer_datetimestamp_from_path_bz2():
+    p = Path('20250720T100145Z.json.bz2')
+    dt = SnapshotSummaryFile.infer_datetimestamp_from_path(p)
+    assert dt == GOLDEN_DT
+
+
+def test_infer_datetimestamp_rejects_diff_filename():
+    p = Path('20250720T100145Z.vrpdiff.json.bz2')
+    with pytest.raises(ValueError):
+        SnapshotSummaryFile.infer_datetimestamp_from_path(p)
+
+
+# --- File I/O unit tests (tmp_path only, no golden data) ---
+
+def test_write_json_roundtrip(tmp_path):
+    sample_data = {'metadata': {'buildtime': '2025-07-20T10:01:45Z'}, 'roas': []}
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
+    f.write_json(sample_data)
+    assert f.local_storage_type == LocalStorageType.UNCOMPRESSED
+    assert f.local_filepath_uncompressed.exists()
+    with f.open_for_read() as fh:
+        loaded = json.load(fh)
+    assert loaded == sample_data
+
+
+def test_bzip2_compress_changes_state(tmp_path):
+    sample_data = {'metadata': {'buildtime': '2025-07-20T10:01:45Z'}, 'roas': []}
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
+    f.write_json(sample_data)
+    f.bzip2_compress()
+    assert f.local_storage_type == LocalStorageType.BZIP2
+    assert f.local_filepath_bz2.exists()
+    assert not f.local_filepath_uncompressed.exists()
+
+
+# --- Golden data tests (read test_data/ only, no S3) ---
+
+@pytest.mark.slow
+def test_infer_local_storage_type_bz2():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_SUMMARY)
+    assert f.local_storage_type == LocalStorageType.BZIP2
+
+
+@pytest.mark.slow
+def test_datetimestamp_from_json():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_SUMMARY)
+    data = f.json_data_cache
+    dt = SnapshotSummaryFile.datetimestamp_from_json(data)
+    assert dt.year == GOLDEN_DT.year
+    assert dt.month == GOLDEN_DT.month
+    assert dt.day == GOLDEN_DT.day
+
+
+@pytest.mark.slow
+def test_json_data_cache_loads():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_SUMMARY)
+    data = f.json_data_cache
+    assert 'metadata' in data
+    assert 'roas' in data
+
+
+@pytest.mark.slow
+def test_validate_size_passes():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_SUMMARY)
+    f.validate_size()
+
+
+@pytest.mark.slow
+def test_write_to_path(tmp_path):
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_SUMMARY)
+    dest = tmp_path / 'out.json.bz2'
+    f.write_to_path(dest)
+    assert dest.exists()
+    with bz2.open(dest, 'rb') as fh:
+        data = json.load(fh)
+    assert 'roas' in data
+
+
+# --- S3 tests (require live AWS credentials) ---
+
+@pytest.mark.slow
+def test_s3_roundtrip(tmp_path, s3_test_bucket):
+    # Copy golden file so s3_upload()'s cleanup_upon_destroy won't touch test_data/
+    local_copy = tmp_path / GOLDEN_SUMMARY.name
+    shutil.copy2(GOLDEN_SUMMARY, local_copy)
+    test_key = f'test_snapshot_summary_file/{GOLDEN_SUMMARY.name}'
+    s3_url = f's3://{s3_test_bucket.name}/{test_key}'
+
+    f = SnapshotSummaryFile(
+        datetimestamp=GOLDEN_DT,
+        local_filepath_bz2=local_copy,
+        local_storage_type=LocalStorageType.BZIP2,
+        s3_url=s3_url,
+    )
+    try:
+        f.s3_upload()
+        assert f.s3_exists()
+
+        download_path = tmp_path / 'downloaded.json.bz2'
+        f2 = SnapshotSummaryFile(
+            datetimestamp=GOLDEN_DT,
+            local_filepath_bz2=download_path,
+            local_storage_type=LocalStorageType.UNCACHED,
+            s3_url=s3_url,
+        )
+        f2.s3_download()
+        assert download_path.exists()
+        with bz2.open(download_path, 'rb') as fh:
+            data = json.load(fh)
+        assert 'metadata' in data
+        assert 'buildtime' in data['metadata']
+    finally:
+        s3_test_bucket.Object(test_key).delete()

--- a/python/rpkilog/tests/test_snapshot_summary_file.py
+++ b/python/rpkilog/tests/test_snapshot_summary_file.py
@@ -74,6 +74,38 @@ def test_bzip2_compress_changes_state(tmp_path):
     assert not f.local_filepath_uncompressed.exists()
 
 
+def test_context_manager_cleans_up_when_flagged(tmp_path):
+    sample_data = {'metadata': {'buildtime': '2025-07-20T10:01:45Z'}, 'roas': []}
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
+    with f as cm:
+        assert cm is f
+        f.write_json(sample_data)
+        f.cleanup_upon_destroy = True
+        local_path = f.local_filepath_uncompressed
+        assert local_path.exists()
+    assert not local_path.exists()
+    assert f.local_storage_type == LocalStorageType.UNCACHED
+
+
+def test_context_manager_keeps_file_when_not_flagged(tmp_path):
+    sample_data = {'metadata': {'buildtime': '2025-07-20T10:01:45Z'}, 'roas': []}
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
+    with f:
+        f.write_json(sample_data)
+        local_path = f.local_filepath_uncompressed
+        assert local_path.exists()
+    assert local_path.exists()
+    assert f.local_storage_type == LocalStorageType.UNCOMPRESSED
+
+
+def test_context_manager_does_not_suppress_exceptions(tmp_path):
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
+    f.cleanup_upon_destroy = True
+    with pytest.raises(ValueError):
+        with f:
+            raise ValueError('boom')
+
+
 # --- Golden data tests (read test_data/ only, no S3) ---
 
 @pytest.mark.slow

--- a/python/rpkilog/tests/test_snapshot_summary_file.py
+++ b/python/rpkilog/tests/test_snapshot_summary_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from rpkilog.cleanup_policy import CleanupPolicy
 from rpkilog.local_storage_type import LocalStorageType
 from rpkilog.snapshot_summary_file import SnapshotSummaryFile
 
@@ -51,6 +52,14 @@ def test_infer_datetimestamp_rejects_diff_filename():
         SnapshotSummaryFile.infer_datetimestamp_from_path(p)
 
 
+def test_datetimestamp_from_json_naive_buildtime_becomes_utc():
+    # buildtime with no timezone indicator must come back tz-aware in UTC
+    json_data = {'metadata': {'buildtime': '2025-07-20 10:01:45'}}
+    dt = SnapshotSummaryFile.datetimestamp_from_json(json_data)
+    assert dt.tzinfo == timezone.utc
+    assert dt == GOLDEN_DT
+
+
 # --- File I/O unit tests (tmp_path only, no golden data) ---
 
 def test_write_json_roundtrip(tmp_path):
@@ -80,7 +89,7 @@ def test_context_manager_cleans_up_when_flagged(tmp_path):
     with f as cm:
         assert cm is f
         f.write_json(sample_data)
-        f.cleanup_upon_destroy = True
+        f.cleanup_policy = CleanupPolicy.CLEANUP_ALWAYS
         local_path = f.local_filepath_uncompressed
         assert local_path.exists()
     assert not local_path.exists()
@@ -100,7 +109,7 @@ def test_context_manager_keeps_file_when_not_flagged(tmp_path):
 
 def test_context_manager_does_not_suppress_exceptions(tmp_path):
     f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
-    f.cleanup_upon_destroy = True
+    f.cleanup_policy = CleanupPolicy.CLEANUP_ALWAYS
     with pytest.raises(ValueError):
         with f:
             raise ValueError('boom')
@@ -158,7 +167,7 @@ def test_write_to_path(tmp_path):
 
 @pytest.mark.slow
 def test_s3_roundtrip(tmp_path, s3_test_bucket):
-    # Copy golden file so s3_upload()'s cleanup_upon_destroy won't touch test_data/
+    # Copy golden file so s3_upload()'s post-upload cleanup won't touch test_data/
     local_copy = tmp_path / GOLDEN_SUMMARY.name
     shutil.copy2(GOLDEN_SUMMARY, local_copy)
     test_key = f'test_snapshot_summary_file/{GOLDEN_SUMMARY.name}'

--- a/python/rpkilog/tests/test_snapshot_summary_file.py
+++ b/python/rpkilog/tests/test_snapshot_summary_file.py
@@ -166,29 +166,30 @@ def test_write_to_path(tmp_path):
 # --- S3 tests (require live AWS credentials) ---
 
 @pytest.mark.slow
-def test_s3_roundtrip(tmp_path, s3_test_bucket):
+def test_s3_roundtrip(tmp_path, s3_test_bucket, s3_base_url_factory):
     # Copy golden file so s3_upload()'s post-upload cleanup won't touch test_data/
     local_copy = tmp_path / GOLDEN_SUMMARY.name
     shutil.copy2(GOLDEN_SUMMARY, local_copy)
-    test_key = f'test_snapshot_summary_file/{GOLDEN_SUMMARY.name}'
-    s3_url = f's3://{s3_test_bucket.name}/{test_key}'
+    # Point the class at a run-unique base URL; the object derives its key from base + filename.
+    s3_base_url_factory(SnapshotSummaryFile, 'test_snapshot_summary_file')
 
     f = SnapshotSummaryFile(
         datetimestamp=GOLDEN_DT,
         local_filepath_bz2=local_copy,
         local_storage_type=LocalStorageType.BZIP2,
-        s3_url=s3_url,
     )
+    test_key = None
     try:
         f.s3_upload()
         assert f.s3_exists()
+        test_key = f.s3_path
 
         download_path = tmp_path / 'downloaded.json.bz2'
         f2 = SnapshotSummaryFile(
             datetimestamp=GOLDEN_DT,
             local_filepath_bz2=download_path,
             local_storage_type=LocalStorageType.UNCACHED,
-            s3_url=s3_url,
+            s3_url=f.s3_url,
         )
         f2.s3_download()
         assert download_path.exists()
@@ -197,4 +198,5 @@ def test_s3_roundtrip(tmp_path, s3_test_bucket):
         assert 'metadata' in data
         assert 'buildtime' in data['metadata']
     finally:
-        s3_test_bucket.Object(test_key).delete()
+        if test_key is not None:
+            s3_test_bucket.Object(test_key).delete()

--- a/python/rpkilog/tests/test_snapshot_summary_file.py
+++ b/python/rpkilog/tests/test_snapshot_summary_file.py
@@ -60,6 +60,44 @@ def test_datetimestamp_from_json_naive_buildtime_becomes_utc():
     assert dt == GOLDEN_DT
 
 
+# --- s3_url derivation unit tests (no network) ---
+
+def test_s3_url_derived_from_base_url_when_unset(monkeypatch):
+    # isolate the process-global base-url classvar (auto-restored on teardown)
+    monkeypatch.setattr(SnapshotSummaryFile, '_default_s3_base_url', None, raising=False)
+    SnapshotSummaryFile.default_s3_base_url_set('s3://example-bucket/prefix/')
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    # resolving derives the URL from base + filename; s3_path/s3_bucket then read the stored URL
+    f._ensure_s3_url()
+    assert f.s3_url == 's3://example-bucket/prefix/20250720T100145Z.json.bz2'
+    assert f.s3_bucket == 'example-bucket'
+    assert f.s3_path == 'prefix/20250720T100145Z.json.bz2'
+
+
+def test_explicit_s3_url_not_overridden_by_base_url(monkeypatch):
+    # A known URL (e.g. a future SQL-loaded record) must win over the class base URL.
+    monkeypatch.setattr(SnapshotSummaryFile, '_default_s3_base_url', None, raising=False)
+    SnapshotSummaryFile.default_s3_base_url_set('s3://example-bucket/prefix/')
+    explicit = 's3://other-bucket/known/object.json.bz2'
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, s3_url=explicit)
+    f._ensure_s3_url()  # must be a no-op when a URL is already known
+    assert f.s3_url == explicit
+    assert f.s3_bucket == 'other-bucket'
+    assert f.s3_path == 'known/object.json.bz2'
+
+
+def test_s3_url_rejects_non_s3_scheme():
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT)
+    with pytest.raises(ValueError):
+        f.s3_url = 'https://example-bucket/object.json.bz2'
+
+
+def test_default_s3_base_url_set_rejects_non_s3_scheme(monkeypatch):
+    monkeypatch.setattr(SnapshotSummaryFile, '_default_s3_base_url', None, raising=False)
+    with pytest.raises(ValueError):
+        SnapshotSummaryFile.default_s3_base_url_set('https://example-bucket/')
+
+
 # --- File I/O unit tests (tmp_path only, no golden data) ---
 
 def test_write_json_roundtrip(tmp_path):

--- a/python/rpkilog/tests/test_vrp_diff_file.py
+++ b/python/rpkilog/tests/test_vrp_diff_file.py
@@ -1,0 +1,132 @@
+import bz2
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from rpkilog.local_storage_type import LocalStorageType
+from rpkilog.vrp_diff_file import VrpDiffFile
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent.parent / 'test_data'
+GOLDEN_DIFF = TEST_DATA_DIR / 'rpkiclient_vrpdiff_20250720T100145Z.json.bz2'
+GOLDEN_DT = datetime(2025, 7, 20, 10, 1, 45, tzinfo=timezone.utc)
+
+
+# --- Unit tests (no disk I/O, no S3) ---
+
+def test_filename_generation():
+    f = VrpDiffFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert f.default_filename == '20250720T100145Z.vrpdiff.json'
+
+
+def test_local_filepath_bz2_appends_extension():
+    f = VrpDiffFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert str(f.local_filepath_bz2).endswith('.vrpdiff.json.bz2')
+
+
+def test_local_filepath_uncompressed_no_bz2_suffix():
+    f = VrpDiffFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert str(f.local_filepath_uncompressed).endswith('.vrpdiff.json')
+    assert not str(f.local_filepath_uncompressed).endswith('.bz2')
+
+
+def test_infer_datetimestamp_from_path_bz2():
+    p = Path('20250720T100145Z.vrpdiff.json.bz2')
+    dt = VrpDiffFile.infer_datetimestamp_from_path(p)
+    assert dt == GOLDEN_DT
+
+
+def test_infer_datetimestamp_from_path_plain():
+    p = Path('20250720T100145Z.vrpdiff.json')
+    dt = VrpDiffFile.infer_datetimestamp_from_path(p)
+    assert dt == GOLDEN_DT
+
+
+def test_infer_datetimestamp_rejects_summary_filename():
+    p = Path('20250720T100145Z.json.bz2')
+    with pytest.raises(ValueError):
+        VrpDiffFile.infer_datetimestamp_from_path(p)
+
+
+def test_from_summary_filename_bz2():
+    f = VrpDiffFile.from_summary_filename('20250720T100145Z.json.bz2', local_storage_dir=Path('/tmp'))
+    assert f.datetimestamp == GOLDEN_DT
+
+
+def test_from_summary_filename_plain():
+    f = VrpDiffFile.from_summary_filename('20250720T100145Z.json', local_storage_dir=Path('/tmp'))
+    assert f.datetimestamp == GOLDEN_DT
+
+
+def test_from_summary_filename_rejects_diff_filename():
+    with pytest.raises(ValueError):
+        VrpDiffFile.from_summary_filename('20250720T100145Z.vrpdiff.json.bz2')
+
+
+# --- Golden data tests (read test_data/ only, no S3) ---
+
+@pytest.mark.slow
+def test_infer_local_storage_type_bz2():
+    f = VrpDiffFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_DIFF)
+    assert f.local_storage_type == LocalStorageType.BZIP2
+
+
+@pytest.mark.slow
+def test_json_data_cache_loads():
+    f = VrpDiffFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_DIFF)
+    data = f.json_data_cache
+    assert 'metadata' in data
+    assert 'vrp_diffs' in data
+
+
+@pytest.mark.slow
+def test_write_to_path(tmp_path):
+    f = VrpDiffFile(datetimestamp=GOLDEN_DT)
+    f.infer_local_storage_type(GOLDEN_DIFF)
+    dest = tmp_path / 'out.vrpdiff.json.bz2'
+    f.write_to_path(dest)
+    assert dest.exists()
+    with bz2.open(dest, 'rb') as fh:
+        data = json.load(fh)
+    assert 'vrp_diffs' in data
+
+
+# --- S3 tests (require live AWS credentials) ---
+
+@pytest.mark.slow
+def test_s3_roundtrip(tmp_path, s3_test_bucket):
+    # Copy golden file so s3_upload()'s cleanup_upon_destroy won't touch test_data/
+    local_copy = tmp_path / GOLDEN_DIFF.name
+    shutil.copy2(GOLDEN_DIFF, local_copy)
+    test_key = f'test_vrp_diff_file/{GOLDEN_DIFF.name}'
+    s3_url = f's3://{s3_test_bucket.name}/{test_key}'
+
+    f = VrpDiffFile(
+        datetimestamp=GOLDEN_DT,
+        local_filepath_bz2=local_copy,
+        local_storage_type=LocalStorageType.BZIP2,
+        s3_url=s3_url,
+    )
+    try:
+        f.s3_upload()
+        assert f.s3_exists()
+
+        download_path = tmp_path / 'downloaded.vrpdiff.json.bz2'
+        f2 = VrpDiffFile(
+            datetimestamp=GOLDEN_DT,
+            local_filepath_bz2=download_path,
+            local_storage_type=LocalStorageType.UNCACHED,
+            s3_url=s3_url,
+        )
+        f2.s3_download()
+        assert download_path.exists()
+        with bz2.open(download_path, 'rb') as fh:
+            data = json.load(fh)
+        assert 'metadata' in data
+        assert 'diff_count' in data['metadata']
+    finally:
+        s3_test_bucket.Object(test_key).delete()

--- a/python/rpkilog/tests/test_vrp_diff_file.py
+++ b/python/rpkilog/tests/test_vrp_diff_file.py
@@ -98,29 +98,30 @@ def test_write_to_path(tmp_path):
 # --- S3 tests (require live AWS credentials) ---
 
 @pytest.mark.slow
-def test_s3_roundtrip(tmp_path, s3_test_bucket):
+def test_s3_roundtrip(tmp_path, s3_test_bucket, s3_base_url_factory):
     # Copy golden file so s3_upload()'s post-upload cleanup won't touch test_data/
     local_copy = tmp_path / GOLDEN_DIFF.name
     shutil.copy2(GOLDEN_DIFF, local_copy)
-    test_key = f'test_vrp_diff_file/{GOLDEN_DIFF.name}'
-    s3_url = f's3://{s3_test_bucket.name}/{test_key}'
+    # Point the class at a run-unique base URL; the object derives its key from base + filename.
+    s3_base_url_factory(VrpDiffFile, 'test_vrp_diff_file')
 
     f = VrpDiffFile(
         datetimestamp=GOLDEN_DT,
         local_filepath_bz2=local_copy,
         local_storage_type=LocalStorageType.BZIP2,
-        s3_url=s3_url,
     )
+    test_key = None
     try:
         f.s3_upload()
         assert f.s3_exists()
+        test_key = f.s3_path
 
         download_path = tmp_path / 'downloaded.vrpdiff.json.bz2'
         f2 = VrpDiffFile(
             datetimestamp=GOLDEN_DT,
             local_filepath_bz2=download_path,
             local_storage_type=LocalStorageType.UNCACHED,
-            s3_url=s3_url,
+            s3_url=f.s3_url,
         )
         f2.s3_download()
         assert download_path.exists()
@@ -129,4 +130,5 @@ def test_s3_roundtrip(tmp_path, s3_test_bucket):
         assert 'metadata' in data
         assert 'diff_count' in data['metadata']
     finally:
-        s3_test_bucket.Object(test_key).delete()
+        if test_key is not None:
+            s3_test_bucket.Object(test_key).delete()

--- a/python/rpkilog/tests/test_vrp_diff_file.py
+++ b/python/rpkilog/tests/test_vrp_diff_file.py
@@ -99,7 +99,7 @@ def test_write_to_path(tmp_path):
 
 @pytest.mark.slow
 def test_s3_roundtrip(tmp_path, s3_test_bucket):
-    # Copy golden file so s3_upload()'s cleanup_upon_destroy won't touch test_data/
+    # Copy golden file so s3_upload()'s post-upload cleanup won't touch test_data/
     local_copy = tmp_path / GOLDEN_DIFF.name
     shutil.copy2(GOLDEN_DIFF, local_copy)
     test_key = f'test_vrp_diff_file/{GOLDEN_DIFF.name}'

--- a/python/rpkilog/tests/test_vrp_diff_file.py
+++ b/python/rpkilog/tests/test_vrp_diff_file.py
@@ -50,19 +50,19 @@ def test_infer_datetimestamp_rejects_summary_filename():
         VrpDiffFile.infer_datetimestamp_from_path(p)
 
 
-def test_from_summary_filename_bz2():
-    f = VrpDiffFile.from_summary_filename('20250720T100145Z.json.bz2', local_storage_dir=Path('/tmp'))
+def test_from_filename_bz2():
+    f = VrpDiffFile.from_filename('20250720T100145Z.json.bz2', local_storage_dir=Path('/tmp'))
     assert f.datetimestamp == GOLDEN_DT
 
 
-def test_from_summary_filename_plain():
-    f = VrpDiffFile.from_summary_filename('20250720T100145Z.json', local_storage_dir=Path('/tmp'))
+def test_from_filename_plain():
+    f = VrpDiffFile.from_filename('20250720T100145Z.json', local_storage_dir=Path('/tmp'))
     assert f.datetimestamp == GOLDEN_DT
 
 
-def test_from_summary_filename_rejects_diff_filename():
+def test_from_filename_rejects_diff_filename():
     with pytest.raises(ValueError):
-        VrpDiffFile.from_summary_filename('20250720T100145Z.vrpdiff.json.bz2')
+        VrpDiffFile.from_filename('20250720T100145Z.vrpdiff.json.bz2')
 
 
 # --- Golden data tests (read test_data/ only, no S3) ---

--- a/python/rpkilog/uv.lock
+++ b/python/rpkilog/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -575,6 +575,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs" },
+    { name = "botocore" },
     { name = "netaddr" },
     { name = "opensearch-py" },
     { name = "psutil" },
@@ -617,6 +618,7 @@ dev = [
 requires-dist = [
     { name = "boto3" },
     { name = "boto3-stubs", specifier = "~=1.43.14" },
+    { name = "botocore", specifier = ">=1.43.14" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "flake8", marker = "extra == 'dev'" },
     { name = "flake8", marker = "extra == 'tests'" },


### PR DESCRIPTION
* add CleanupPolicy(StrEnum): CLEANUP_ALWAYS, CLEANUP_NEVER, CLEANUP_IF_IN_S3
* avoid unlinking rpkiclient output/json file
* Gate __del__/__exit__ on new _should_cleanup(); s3_upload() no longer sets a cleanup flag, relying on s3_stored