### PR TITLE
GH-81: refactor archive_site_crawler.py onto DataFileSuper

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(python -m pytest tests/test_vrp_diff_list.py -v -m \"not slow\")",
       "WebFetch(domain:registry.terraform.io)",
       "Bash(terraform fmt *)",
-      "Bash(terraform validate *)"
+      "Bash(terraform validate *)",
+      "mcp__ide__getDiagnostics"
     ]
   }
 }

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -47,6 +47,7 @@ jobs:
               python/rpkilog/rpkilog/data_file_super.py
               python/rpkilog/rpkilog/local_storage_type.py
               python/rpkilog/rpkilog/roa.py
+              python/rpkilog/rpkilog/snapshot_file.py
               python/rpkilog/rpkilog/snapshot_summary_file.py
               python/rpkilog/rpkilog/util.py
               python/rpkilog/rpkilog/vrp_diff_file.py

--- a/python/rpkilog/rpkilog/archive_site_crawler.py
+++ b/python/rpkilog/rpkilog/archive_site_crawler.py
@@ -1,31 +1,34 @@
 #!/usr/bin/env python
-""""
+"""
 Crawl an HTTP index of RPKI archive data and download desirable files.  Upload those files to S3.
 
-TODO: Ensure we have --filename-datetime-min and --filename-datetime-max arguments which allow us to
-  download & process only files with datetime values in their names which fall between those arguments.
-  The arguments should be supported separately and together.
+For each discovered RPKI archive TAR we don't already have, download it, validate it, extract the
+rpki-client summary JSON, and upload the TAR to the snapshot bucket and the summary to the summary
+bucket.  The file/storage/S3 concerns are delegated to SnapshotFile and SnapshotSummaryFile; this
+module owns acquisition (crawling, downloading, retry) and orchestration.
+
+--filename-datetime-min / --filename-datetime-max restrict processing to snapshots whose filename
+datetime falls within the given bounds.  They may be used separately or together.
 """
 import argparse
 import boto3
-import bz2
 from datetime import datetime, timedelta, UTC
 import dateutil
 from html.parser import HTMLParser
-import inspect
-from inspect import Parameter
 import json
 import logging
 import os
-import re
 import requests
 from pathlib import Path
-import tarfile
 import tempfile
 from urllib.parse import urlparse
 
 import tenacity
 
+from rpkilog.cleanup_policy import CleanupPolicy
+from rpkilog.local_storage_type import LocalStorageType
+from rpkilog.snapshot_file import SnapshotFile
+from rpkilog.snapshot_summary_file import SnapshotSummaryFile
 from rpkilog.util import list_s3_snapshot_files_within_range, list_s3_summary_files_within_range
 
 
@@ -72,118 +75,78 @@ class ArchiveSiteCrawler():
     }
     fetch_index_page_timeout = 10
     fetch_snapshot_timeout = 300
-    s3_snapshot_bucket_name: str
-
-    @classmethod
-    def extract_matching_file_from_tar(
-        cls,
-        input_tar:Path,
-        output_dir:Path,
-        find_file_re:str=None,
-        bzip_result_file:bool=True,
-    ) -> Path:
-        '''
-        Extract file matching find_file_re from given TAR file.  Name the resulting file based on contatenation
-        of the regex match groups.  Optionally, bzip the file and add '.bz2' to the filename.
-
-        Returns a Path object to the resulting file on disk.
-        '''
-        if find_file_re==None: find_file_re=r'^rpki-(\d{8}T\d{6}Z)/output/rpki-client(.json)$'
-        logger.info(F'Extracting useful JSON data from {input_tar}')
-        tf = tarfile.open(name=input_tar, mode='r')
-        for member in tf.getmembers():
-            if not member.isfile():
-                continue
-            rem = re.match(find_file_re, member.name)
-            if not rem:
-                continue
-            result_file_name = ''.join(rem.groups())
-            if not len(result_file_name):
-                raise ValueError(F'Matching file {member.name} has no regex groups matching. Need those for filename.')
-            ef = tf.extractfile(member)
-            if bzip_result_file:
-                result_path = Path(output_dir, result_file_name + '.bz2')
-                output_file = bz2.open(result_path, mode='xb')
-            else:
-                result_path = Path(output_dir, result_file_name)
-                output_file = open(result_path, 'xb')
-            output_file.write(ef.read())
-            output_file.close()
-            return result_path
-        else:
-            raise KeyError(F'No matching file found in TAR file {input_tar}')
 
     @classmethod
     @tenacity.retry(before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
                     stop=tenacity.stop_after_attempt(5),
                     wait=tenacity.wait_random(min=3, max=10),
                     )
-    def fetch_tar_file_and_extract_summary(
-            cls,
-            s3_snapshot_destination_filename: str,
-            uploaded: list,
-            url,
-    ) -> Path | None:
-        """
-        Passing the list `uploaded` into this function and modifying it is ugly.  It should instead return
-        a complex type, or modify something like cls.uploaded_snapshots.  We'll be ugly for now.
+    def download_tar(cls, url: str, dest_path: Path):
+        '''
+        Download the RPKI archive TAR at url to dest_path, streaming to disk.
 
-        Additionally, this method does too much.  It's an improvement from what we had before, but this
-        can be de-composed a bit more sensibly.
-        """
-        logger.info(F'DOWNLOADING {url}')
-        # get a temporary file
-        with tempfile.NamedTemporaryFile(mode='w+b', delete=True) as tar_tempfile:
-            # download
-            try:
-                count_bytes_downloaded = 0
-                with requests.get(url=url, stream=True, timeout=cls.fetch_snapshot_timeout) as tar_response:
-                    tar_response.raise_for_status()
-                    for chunk in tar_response.iter_content(chunk_size=1024*64):
+        Acquisition only: the per-archive transport + retry policy live here, NOT on SnapshotFile.
+        Raises RuntimeError (with download progress) on failure so the caller aborts rather than
+        silently skipping a file.  Retried by the tenacity decorator above.
+        '''
+        logger.info(f'DOWNLOADING {url}')
+        count_bytes_downloaded = 0
+        tar_response = None
+        try:
+            with requests.get(url=url, stream=True, timeout=cls.fetch_snapshot_timeout) as tar_response:
+                tar_response.raise_for_status()
+                with open(dest_path, 'wb') as dest_fh:
+                    for chunk in tar_response.iter_content(chunk_size=1024 * 64):
                         count_bytes_downloaded += len(chunk)
-                        tar_tempfile.write(chunk)
-                    tar_tempfile.flush()
-            except Exception as exc:
-                if 'Content-Length' in tar_response.headers:
-                    content_length = int(tar_response.headers['Content-Length'])
-                    percent_downloaded = count_bytes_downloaded / content_length * 100
-                    raise RuntimeError(
-                        f'Failed downloading {url} after {percent_downloaded}%'
-                        f' bytes {count_bytes_downloaded:.0f} of {content_length}'
-                    ) from exc
-                else:
-                    raise RuntimeError(f'Failed downloading {url} after {count_bytes_downloaded}') from exc
+                        dest_fh.write(chunk)
+        except Exception as exc:
+            if tar_response is not None and 'Content-Length' in tar_response.headers:
+                content_length = int(tar_response.headers['Content-Length'])
+                percent_downloaded = count_bytes_downloaded / content_length * 100
+                raise RuntimeError(
+                    f'Failed downloading {url} after {percent_downloaded:.0f}%'
+                    f' bytes {count_bytes_downloaded} of {content_length}'
+                ) from exc
+            raise RuntimeError(
+                f'Failed downloading {url} after {count_bytes_downloaded} bytes'
+            ) from exc
 
-            try:
-                logger.info(f'VALIDATING tar file can be read {tar_tempfile.name}')
-                # iterate through the tar file's members
-                # if the file is truncated, this should raise an exception, eliminating partial downloads
-                with tarfile.open(tar_tempfile.name, 'r:*') as tar_test_reader:
-                    for member in tar_test_reader.getmembers():
-                        if not member.isfile():
-                            continue
-                        member_reader = tar_test_reader.extractfile(member)
-                        member_size = 0
-                        while chunk := member_reader.read(1024*64):
-                            member_size += len(chunk)
-            except Exception as exc:
-                logger.exception(f'TAR_FAILED_VALIDATION skipping {url} {tar_tempfile.name}')
+    @classmethod
+    def process_tar_url(cls, url: str, datetimestamp: datetime) -> str | None:
+        '''
+        Download one archive TAR, validate it, extract its summary, and upload both the TAR (to the
+        snapshot bucket) and the summary (to the summary bucket).
+
+        Acquisition (download + retry) lives in download_tar(); every file/storage/S3 concern is
+        delegated to SnapshotFile / SnapshotSummaryFile.  SnapshotFile.default_s3_base_url and
+        SnapshotSummaryFile.default_s3_base_url must already be set (see wrapped_entry_point).
+
+        Returns the snapshot's S3 key on success, or None when the TAR failed validation and was
+        skipped (a later run re-downloads it).  Raises on download or upload failure (so the job
+        aborts rather than silently skipping a file).  All local temp files live under a
+        TemporaryDirectory that is removed on return.
+        '''
+        with tempfile.TemporaryDirectory() as work_dir_str:
+            work_dir = Path(work_dir_str)
+            snapshot = SnapshotFile(
+                datetimestamp=datetimestamp,
+                local_storage_dir=work_dir,
+                local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+                source_url=url,
+                cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+            )
+            cls.download_tar(url=url, dest_path=snapshot.local_filepath_tgz)
+            if not snapshot.validate_tar():
+                logger.warning(f'TAR_FAILED_VALIDATION skipping {url}')
                 return None
-
-            logger.info(F'EXTRACTING useful summary file from tar')
-            json_file_path = cls.extract_matching_file_from_tar(
-                input_tar=Path(tar_tempfile.name),
-                output_dir=Path('/tmp'),
-            )
-
-            logger.info(F'UPLOADING {tar_tempfile.name} to {cls.s3_snapshot_bucket_name}')
-            cls.s3.upload_file(
-                Filename=str(tar_tempfile.name),
-                Bucket=cls.s3_snapshot_bucket_name,
-                Key=s3_snapshot_destination_filename,
-            )
-            uploaded.append(s3_snapshot_destination_filename)
-            return json_file_path
+            summary = snapshot.extract_summary_file(output_dir=work_dir)
+            summary.cleanup_policy = CleanupPolicy.CLEANUP_NEVER
+            logger.info(f'UPLOADING snapshot {snapshot.default_filename} to snapshot bucket')
+            snapshot.s3_upload()
+            logger.info(f'UPLOADING summary {summary.default_filename} to summary bucket')
+            summary.s3_upload()
+            retstr = snapshot.s3_path
+        return retstr
 
     @classmethod
     def fetch_tar_urls_from_archive_site(
@@ -233,12 +196,13 @@ class ArchiveSiteCrawler():
         for url in sorted(urls_on_day_page):
             if not url.startswith(day_page_url):
                 continue
-            relative_url = url[len(site_root):]
-            rem = re.search(r'rpki-(?P<datetime>\d{8}T\d{6})Z.tgz$', relative_url)
-            if not rem:
+            try:
+                tar_datetime = SnapshotFile.infer_datetimestamp_from_path(Path(url))
+            except ValueError:
+                # not an 'rpki-...Z.tgz' link (parent-dir links, other files, etc.)
                 continue
-            if dateutil.parser.parse(rem.group('datetime')) < start_date:
-                logger.debug(F'Not crawling into {relative_url} because it is before {start_date.isoformat()}')
+            if tar_datetime.replace(tzinfo=None) < start_date:
+                logger.debug(F'Not crawling into {url} because it is before {start_date.isoformat()}')
                 continue
             tar_file_urls.add(url)
         return(tar_file_urls)
@@ -278,6 +242,10 @@ class ArchiveSiteCrawler():
         ap.add_argument('--s3-snapshot-summary-bucket-name', help='S3 bucket containing JSON summary files')
         ap.add_argument('--site-root', help='Root of web archive site')
         ap.add_argument('--start-date', type=dateutil.parser.parse, help='Do not download snapshots earlier than this date')
+        ap.add_argument('--filename-datetime-min', type=dateutil.parser.parse,
+                        help='Only process snapshots whose filename datetime is >= this (optional)')
+        ap.add_argument('--filename-datetime-max', type=dateutil.parser.parse,
+                        help='Only process snapshots whose filename datetime is <= this (optional)')
         ap.add_argument('--job-max-runtime', type=float, help='Max runtime in seconds (default: unlimited)')
         ap.add_argument('--job-max-downloads', default=2, type=int, help='Max files to download before stopping (default: 2)')
         args = vars(ap.parse_args())
@@ -311,17 +279,19 @@ class ArchiveSiteCrawler():
         debug_save_urls: Path | None = None,
         fetch_snapshot_timeout: str = None,
         start_date:datetime=None,
+        filename_datetime_min:datetime=None,
+        filename_datetime_max:datetime=None,
         minimum_file_age:timedelta=None,
         maximum_crawl_age:str=None,
         job_deadline:datetime=None,
         job_max_downloads:int=None,
     ):
         '''
-        Invoked by other entry points, e.g. cli_entry_point, aws_lambda_entry_point
+        Invoked by other entry points, e.g. cli_entry_point.
 
         Web-crawl the given site_root and find relevant RPKI archive TAR URLs in the HTML a-tags.
         Crawling will try to avoid requesting pages that list only TAR files before start_date.
-        
+
         Get the list of already-downloaded RPKI TARs by listing the s3_snapshot_summary_bucket
         and comparing the date-based filenames, for example:
             snapshot_summary: 20211121T000709Z.json.bz2
@@ -331,16 +301,22 @@ class ArchiveSiteCrawler():
         some to-be-processed TARs already there.
 
         In ascending date-based order, download any TAR files we haven't previously processed,
-        except TAR files with a datetime-based filename before start_date.
+        except TAR files with a datetime-based filename before start_date or outside the optional
+        [filename_datetime_min, filename_datetime_max] bounds (each bound applies independently).
 
-        After downloading each TAR, upload it to the s3_snapshot_bucket_name.
-
-        Extract relevant JSON summary from each TAR and upload that to the s3_snapshot_summary_bucket_name.
+        For each such TAR, process_tar_url() uploads the TAR to s3_snapshot_bucket_name and its
+        extracted summary to s3_snapshot_summary_bucket_name (both via SnapshotFile /
+        SnapshotSummaryFile, whose default S3 base URLs are set below from the bucket names).
 
         Abort if a download fails, or if an upload fails, to avoid skipping any files.
         '''
-        cls.s3 = boto3.client('s3')
-        cls.s3_snapshot_bucket_name = s3_snapshot_bucket_name
+        SnapshotFile.default_s3_base_url_set(f's3://{s3_snapshot_bucket_name}/')
+        SnapshotSummaryFile.default_s3_base_url_set(f's3://{s3_snapshot_summary_bucket_name}/')
+
+        if filename_datetime_min is not None:
+            filename_datetime_min = filename_datetime_min.replace(tzinfo=None)
+        if filename_datetime_max is not None:
+            filename_datetime_max = filename_datetime_max.replace(tzinfo=None)
 
         if maximum_crawl_age:
             maximum_crawl_age = timedelta(days=float(maximum_crawl_age))
@@ -366,25 +342,27 @@ class ArchiveSiteCrawler():
             end_datetime=datetime.now(UTC).replace(tzinfo=None),
         )
         for buckobj in snapshots:
-            rem = re.search(r'^rpki-(?P<datetime>\d{8}T\d{6})Z\.', buckobj.key)
-            if rem:
-                already_have_by_datetime[rem.group('datetime')] = buckobj
-            else:
+            try:
+                buckobj_datetime = SnapshotFile.infer_datetimestamp_from_path(Path(buckobj.key))
+            except ValueError:
                 logger.warning(f'UNMATCHED key in snapshot bucket {snapshot_bucket} : {buckobj.key}')
+                continue
+            already_have_by_datetime[buckobj_datetime] = buckobj
 
-        cls.s3_summary_bucket = boto3.resource('s3').Bucket(s3_snapshot_summary_bucket_name)
+        summary_bucket = boto3.resource('s3').Bucket(s3_snapshot_summary_bucket_name)
         summaries = list_s3_summary_files_within_range(
-            bucket=cls.s3_summary_bucket,
+            bucket=summary_bucket,
             start_datetime=start_date - timedelta(days=1),
             end_datetime=datetime.now(UTC).replace(tzinfo=None),
         )
         for buckobj in summaries:
-            rem = re.search(r'^(?P<datetime>\d{8}T\d{6})Z.json', buckobj.key)
-            if rem:
-                already_have_by_datetime[rem.group('datetime')] = buckobj
-            else:
-                logger.warning('UNMATCHED key in summary bucket {summary_bucket} : {buckobj.key}')
-        logger.info(F'LISTED {len(snapshots)} snapshots and {len(summaries)} summaires in S3 buckets.')
+            try:
+                buckobj_datetime = SnapshotSummaryFile.infer_datetimestamp_from_path(Path(buckobj.key))
+            except ValueError:
+                logger.warning(f'UNMATCHED key in summary bucket {summary_bucket} : {buckobj.key}')
+                continue
+            already_have_by_datetime[buckobj_datetime] = buckobj
+        logger.info(F'LISTED {len(snapshots)} snapshots and {len(summaries)} summaries in S3 buckets.')
 
         # get the list of all rpki tar files, after start_date, from the specified rpki archive site
         archive_site_available_tar_file_urls = cls.fetch_tar_urls_from_archive_site(
@@ -405,17 +383,20 @@ class ArchiveSiteCrawler():
         # Determine which ones we don't already have.  Download those from archive and re-upload to snapshot bucket.
         # Stop if we're within 60s of job_deadline (lambda runtime might be exhausted because the downloads are slow.)
         for available_tar_url in sorted(archive_site_available_tar_file_urls):
-            rem = re.search(r'(?P<filename>rpki-(?P<datetime>\d{8}T\d{6})Z\.tgz)$', available_tar_url)
-            if not rem:
+            try:
+                available_tar_datetime = SnapshotFile.infer_datetimestamp_from_path(Path(available_tar_url))
+            except ValueError:
                 logger.warning(F'UNMATCHED available_tar_url {available_tar_url}')
                 continue
-            available_tar_datetimestr = rem.group('datetime')
-            destination_filename = rem.group('filename')
-            if available_tar_datetimestr in already_have_by_datetime:
+            if available_tar_datetime in already_have_by_datetime:
                 # we've previously downloaded this tar from the archive site
                 continue
-            available_tar_datetime = dateutil.parser.parse(available_tar_datetimestr)
-            available_tar_age = datetime.now(UTC).replace(tzinfo=None) - available_tar_datetime
+            available_tar_datetime_naive = available_tar_datetime.replace(tzinfo=None)
+            if filename_datetime_min is not None and available_tar_datetime_naive < filename_datetime_min:
+                continue
+            if filename_datetime_max is not None and available_tar_datetime_naive > filename_datetime_max:
+                continue
+            available_tar_age = datetime.now(UTC).replace(tzinfo=None) - available_tar_datetime_naive
             if available_tar_age < minimum_file_age:
                 # file is too young; skip it.  A future iteration will download it.
                 # This is a workaround for some archive sites writing files into their public directories
@@ -426,25 +407,15 @@ class ArchiveSiteCrawler():
             # new tar we need from archive site
             if job_deadline!=None and job_deadline < datetime.utcnow():
                 # We're past the deadline.  Could run out of lambda execution time.  Stop here.
-                logger.warn(F'JOB_DEADLINE reached.')
+                logger.warning(F'JOB_DEADLINE reached.')
                 break
             if job_max_downloads!=None and job_max_downloads <= len(uploaded):
-                logger.warn(F'JOB_MAX_DOWNLOADS reached.')
+                logger.warning(F'JOB_MAX_DOWNLOADS reached.')
                 break
 
-            json_file_path = cls.fetch_tar_file_and_extract_summary(
-                s3_snapshot_destination_filename=destination_filename,
-                uploaded=uploaded,
-                url=available_tar_url,
-            )
-            if json_file_path is None:
+            snapshot_key = cls.process_tar_url(url=available_tar_url, datetimestamp=available_tar_datetime)
+            if snapshot_key is None:
                 continue
-            logger.info(F'UPLOADING extracted file {json_file_path.name} to {s3_snapshot_summary_bucket_name}')
-            cls.s3.upload_file(
-                Filename=str(json_file_path),
-                Bucket=s3_snapshot_summary_bucket_name,
-                Key=json_file_path.name,
-            )
-            os.remove(json_file_path)
+            uploaded.append(snapshot_key)
 
         return uploaded

--- a/python/rpkilog/rpkilog/archive_site_crawler.py
+++ b/python/rpkilog/rpkilog/archive_site_crawler.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-'''
-Crawl an HTTP index of RPKI archive data and download desirable files.
+""""
+Crawl an HTTP index of RPKI archive data and download desirable files.  Upload those files to S3.
 
-Upload those files to S3.
-
-TODO: Move to its own module.
-'''
+TODO: Ensure we have --filename-datetime-min and --filename-datetime-max arguments which allow us to
+  download & process only files with datetime values in their names which fall between those arguments.
+  The arguments should be supported separately and together.
+"""
 import argparse
 import boto3
 import bz2

--- a/python/rpkilog/rpkilog/archive_site_crawler.py
+++ b/python/rpkilog/rpkilog/archive_site_crawler.py
@@ -260,32 +260,6 @@ class ArchiveSiteCrawler():
         return parser.href_urls
 
     @classmethod
-    def aws_lambda_entry_point(cls, event, context):
-        '''
-        TODO: Move this to AWS Lambda wrapper for use everywhere.
-        TODO: CORS options.
-        TODO: Web requests & return values w/ exception handling.
-        '''
-        logging.basicConfig(level='INFO')
-        args = {}
-        sig = inspect.signature(cls.wrapped_entry_point)
-        if 'job_deadline' in sig.parameters:
-            args['job_deadline'] = datetime.utcnow() + timedelta(milliseconds=context.get_remaining_time_in_millis())
-        for pname, param in sig.parameters:
-            if param.default == Parameter.empty:
-                # required
-                pass
-            if param.annotation == Parameter.empty:
-                pass
-            elif param.annotation in [list, set]:
-                raise NotImplemented('Need to convert input to list or set')
-            penv = os.getenv(pname)
-            if penv != None:
-                args[pname] = penv
-        wrapped_retval = cls.wrapped_entry_point(**args)
-        return wrapped_retval
-
-    @classmethod
     def cli_entry_point(cls):
         realtime_initial = datetime.utcnow()
         logging.basicConfig(

--- a/python/rpkilog/rpkilog/data_file_super.py
+++ b/python/rpkilog/rpkilog/data_file_super.py
@@ -136,6 +136,9 @@ class DataFileSuper(ABC):
         """
         Unlink the locally-cached file (if any) and mark storage as UNCACHED.  Shared by __del__
         and __exit__; callers gate on _should_cleanup().
+
+        The default case raises so an unhandled storage state (e.g. SNAPSHOT_TGZ, which SnapshotFile
+        overrides this method to clean up) fails loudly rather than silently leaking the cache.
         """
         match self.local_storage_type:
             case LocalStorageType.UNCOMPRESSED:
@@ -146,6 +149,8 @@ class DataFileSuper(ABC):
                 self.local_storage_type = LocalStorageType.UNCACHED
             case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
                 pass
+            case _:
+                raise ValueError(f'unexpected value of local_storage_type: {self}')
 
     def __repr__(self):
         """

--- a/python/rpkilog/rpkilog/local_storage_type.py
+++ b/python/rpkilog/rpkilog/local_storage_type.py
@@ -3,6 +3,20 @@ from enum import Enum
 
 class LocalStorageType(Enum):
     UNSPECIFIED = 0
+    """No local-cache state has been established yet (freshly constructed)."""
+
     UNCACHED = 1
+    """No local copy exists; the bytes live only in S3 and must be downloaded to use."""
+
     UNCOMPRESSED = 2
+    """A locally-cached plain (uncompressed) JSON file at local_filepath_uncompressed."""
+
     BZIP2 = 3
+    """A locally-cached bzip2-compressed JSON file at local_filepath_bz2."""
+
+    SNAPSHOT_TGZ = 4
+    """A locally-cached gzipped RPKI archive TAR (rpki-...Z.tgz) at local_filepath_tgz.
+
+    Opaque binary blob, NOT a JSON document: it is uploaded/downloaded byte-for-byte and is never
+    bz2-recompressed or JSON-parsed.  Used only by SnapshotFile.
+    """

--- a/python/rpkilog/rpkilog/snapshot_file.py
+++ b/python/rpkilog/rpkilog/snapshot_file.py
@@ -1,0 +1,300 @@
+"""
+SnapshotFile: represents an RPKI archive snapshot TAR (rpki-YYYYMMDDTHHMMSSZ.tgz).
+
+A "snapshot" is the gzipped TAR published by an upstream RPKI archive site and re-hosted by rpkilog in
+the snapshot S3 bucket.  Each snapshot TAR contains, among other things, the rpki-client output JSON
+that we extract into a SnapshotSummaryFile.  This class is the planned home for the snapshot-TAR
+*file* concerns currently scattered through archive_site_crawler.py: filename/datetime derivation,
+validating the TAR, extracting the summary, and uploading the TAR to S3.
+
+STATUS: the storage model is implemented.  A snapshot's cached bytes are an opaque gzipped TAR
+(LocalStorageType.SNAPSHOT_TGZ) held at local_filepath_tgz.  Operations that only make sense for a
+JSON document raise (see the type-invalid overrides below), the S3 round-trip moves the TAR
+byte-for-byte under its '.tgz' key, and local-cache cleanup unlinks the TAR.  The domain I/O methods
+(validate_tar, extract_summary_file) remain stubs, and archive_site_crawler is NOT yet rebased onto
+this class; both are a separate, later task.
+
+Design notes:
+  - SnapshotFile does NOT acquire bytes from, or parse the URLs of, the archive site.  Acquisition
+    (transport, auth, headers, timeouts, retry/backoff, mirror failover) varies per archive and is
+    owned by the crawler (and a possible future ArchiveSite abstraction), which downloads to a temp
+    path and then points a SnapshotFile at it (local_filepath_tgz + SNAPSHOT_TGZ).  This is why
+    s3_download() lives here (rehydrating from rpkilog's own canonical store, one transport) but no
+    archive-download method does.  source_url is kept purely as provenance metadata.
+  - Cache *state* is modeled by LocalStorageType; "operation invalid for this file *type*" is a
+    type-level override here.  The two are orthogonal: DataFileSuper's match statements all carry a
+    `case _: raise` default as a safety net for an unhandled state, while the JSON-only operations
+    below raise regardless of state because a snapshot TAR is simply not a JSON document.
+  - The inherited local_filepath_uncompressed / local_filepath_bz2 properties are overridden to
+    raise; a snapshot has no uncompressed-JSON or bz2 form.  repr_attrs is redefined accordingly so
+    __repr__ (used in error messages) does not trip those raises.
+
+TODO(sql-files-table): When the SQL files table lands, a SnapshotFile should map to a row recording
+  at least: datetimestamp, source_url (archive origin), s3_url, byte size, and a content hash; plus a
+  link to the SnapshotSummaryFile row extracted from it.  Construction from a SQL row should pass an
+  explicit s3_url so the instance never consults the process-global default base URL (DataFileSuper
+  already supports known-url instances).  Decide whether to_sql_row()/from_sql_row() belong here or
+  on DataFileSuper, shared by all file types.
+
+TODO(crawler-rebase): the later archive_site_crawler.py refactor should replace these in-line pieces
+  with the methods here:
+    - S3-key / filename regex matching of 'rpki-...Z.tgz'      -> infer_datetimestamp_from_path()
+    - destination filename derivation                          -> default_filename
+    - day-page archive-URL parsing + streaming requests.get()  -> stays in the crawler / future
+      download                                                    ArchiveSite; construct a SnapshotFile
+                                                                  from the downloaded temp path
+                                                                  (local_filepath_tgz + SNAPSHOT_TGZ)
+    - tarfile readability check                                -> validate_tar()
+    - extract_matching_file_from_tar() + summary handling      -> extract_summary_file()
+    - cls.s3.upload_file(...) of the TAR to the snapshot bucket -> s3_upload()
+"""
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+import boto3
+import dateutil.parser
+
+from rpkilog.data_file_super import DataFileSuper
+from rpkilog.local_storage_type import LocalStorageType
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotFile(DataFileSuper):
+    """
+    Represents an RPKI archive snapshot TAR: rpki-YYYYMMDDTHHMMSSZ.tgz
+
+    Published by an upstream RPKI archive site and re-hosted by rpkilog in the snapshot S3 bucket.
+    See the module docstring for design notes and outstanding TODOs.
+    """
+    default_filename_strftime_expression = 'rpki-%Y%m%dT%H%M%SZ.tgz'
+    # __repr__ iterates repr_attrs via getattr(self, name, None), which only swallows AttributeError;
+    # the inherited local_filepath_uncompressed/_bz2 raise on a SnapshotFile, so they are dropped
+    # here in favor of local_filepath_tgz (and source_url is added).
+    repr_attrs = [
+        'datetimestamp',
+        'local_filepath_tgz',
+        'local_storage_type',
+        's3_url',
+        's3_stored',
+        'source_url',
+    ]
+
+    # Regex matching the rpki-client summary JSON member inside a snapshot TAR, e.g.
+    # 'rpki-20211121T000709Z/output/rpki-client.json'.  Group 1 is the YYYYMMDDTHHMMSSZ stamp and
+    # group 2 is '.json'.  archive_site_crawler.extract_matching_file_from_tar() owns this today;
+    # extract_summary_file() will use it once implemented.
+    summary_member_re = r'^rpki-(\d{8}T\d{6}Z)/output/rpki-client(\.json)$'
+
+    def __init__(self, *args, source_url: str = None, local_filepath_tgz: Path = None, **kwargs):
+        """
+        Add source_url and local_filepath_tgz on top of the DataFileSuper constructor.
+
+        source_url is the archive-site HTTP URL this snapshot originated from, recorded purely as
+        provenance metadata (logging + a planned column in the SQL files table); SnapshotFile never
+        fetches it.  It is None for snapshots discovered via S3 listing or loaded from SQL.
+
+        local_filepath_tgz is the locally-cached '.tgz' path; when None it defaults (via the property
+        below) to local_storage_dir / default_filename.
+        """
+        super().__init__(*args, **kwargs)
+        self.source_url = source_url
+        self.local_filepath_tgz = local_filepath_tgz
+
+    @classmethod
+    def infer_datetimestamp_from_path(cls, path) -> datetime:
+        """Extract datetime from a snapshot TAR filename; rejects summary and vrpdiff filenames."""
+        rem = re.search(r'rpki-(?P<dt>\d{8}T\d{6}Z)\.tgz$', str(path.name))
+        if not rem:
+            raise ValueError(f'regex did not match a snapshot TAR filename in given path: {path}')
+        dt = dateutil.parser.parse(rem.group('dt'))
+        retval = dt.replace(tzinfo=timezone.utc)
+        return retval
+
+    # --- local-file path representation ---------------------------------------------------------
+
+    @property
+    def local_filepath_tgz(self) -> Path:
+        if self._local_filepath_tgz:
+            return self._local_filepath_tgz
+        retpath = Path(self.local_storage_dir, self.default_filename)
+        return retpath
+
+    @local_filepath_tgz.setter
+    def local_filepath_tgz(self, value: Path):
+        self._local_filepath_tgz = value
+
+    @property
+    def local_filepath_uncompressed(self) -> Path:
+        raise TypeError('a snapshot TAR has no uncompressed-JSON form; use local_filepath_tgz')
+
+    @local_filepath_uncompressed.setter
+    def local_filepath_uncompressed(self, value: Path):
+        # DataFileSuper.__init__ assigns None here; reject any real JSON path on a SnapshotFile.
+        if value is not None:
+            raise TypeError('a snapshot TAR has no uncompressed-JSON form; use local_filepath_tgz')
+
+    @property
+    def local_filepath_bz2(self) -> Path:
+        raise TypeError('a snapshot TAR has no bz2 form; use local_filepath_tgz')
+
+    @local_filepath_bz2.setter
+    def local_filepath_bz2(self, value: Path):
+        # DataFileSuper.__init__ assigns None here; reject any real bz2 path on a SnapshotFile.
+        if value is not None:
+            raise TypeError('a snapshot TAR has no bz2 form; use local_filepath_tgz')
+
+    # --- S3 (move the TAR byte-for-byte; no bz2 recompression, no '.bz2' suffix) -----------------
+
+    def s3_url_set_to_default(self):
+        """
+        Override of DataFileSuper.s3_url_set_to_default(), which appends '.bz2'.
+
+        A snapshot's S3 key is its '.tgz' filename as-is, so derive 's3://<base>/rpki-...Z.tgz' with
+        no suffix.  Sets self.s3_url and returns it.
+        """
+        retstr = self.default_s3_base_url_get() + str(self.default_filename)
+        self.s3_url = retstr
+        return retstr
+
+    def s3_upload(self):
+        """
+        Upload the locally-cached snapshot TAR to S3 byte-for-byte under its '.tgz' key.
+
+        Override of DataFileSuper.s3_upload(), which bzip2-compresses UNCOMPRESSED data and streams
+        BZIP2 data — neither is correct for an already-gzipped TAR.  Sets s3_stored / s3_url and
+        returns the created object so CleanupPolicy still functions.
+        """
+        self._ensure_s3_url()
+        bucket = boto3.resource('s3').Bucket(self.s3_bucket)
+        match self.local_storage_type:
+            case LocalStorageType.SNAPSHOT_TGZ:
+                with open(self.local_filepath_tgz, 'rb') as tgz_fh:
+                    s3_object = bucket.put_object(Key=self.s3_path, Body=tgz_fh)
+            case _:
+                raise ValueError(f'cannot upload a snapshot without a local .tgz file: {self}')
+        self.s3_stored = True
+        self.s3_url = f's3://{self.s3_bucket}/{self.s3_path}'
+        logger.info(f'uploaded {self.s3_url}')
+        return s3_object
+
+    def s3_download(self):
+        """
+        Download the snapshot TAR from S3 into local_filepath_tgz and set local_storage_type to
+        SNAPSHOT_TGZ (DataFileSuper.s3_download() hard-codes BZIP2, which is wrong for a TAR).
+        """
+        self._ensure_s3_url()
+        bucket = boto3.resource('s3').Bucket(self.s3_bucket)
+        bucket.download_file(Key=self.s3_path, Filename=str(self.local_filepath_tgz))
+        self.local_storage_type = LocalStorageType.SNAPSHOT_TGZ
+
+    def write_to_path(self, dest: Path):
+        """Copy the locally-cached TAR to dest, downloading from S3 first if UNCACHED."""
+        match self.local_storage_type:
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
+                self.s3_download()
+                shutil.copy2(self.local_filepath_tgz, dest)
+            case LocalStorageType.SNAPSHOT_TGZ:
+                shutil.copy2(self.local_filepath_tgz, dest)
+            case _:
+                raise ValueError(f'unexpected value of local_storage_type: {self}')
+
+    # --- local-cache cleanup --------------------------------------------------------------------
+
+    def _cleanup_local_cache(self):
+        """
+        Unlink the locally-cached TAR (if any) and mark storage as UNCACHED.  Shared by __del__ and
+        __exit__; callers gate on _should_cleanup().
+        """
+        match self.local_storage_type:
+            case LocalStorageType.SNAPSHOT_TGZ:
+                os.unlink(self.local_filepath_tgz)
+                self.local_storage_type = LocalStorageType.UNCACHED
+            case LocalStorageType.UNCACHED | LocalStorageType.UNSPECIFIED:
+                pass
+            case _:
+                raise ValueError(f'unexpected value of local_storage_type: {self}')
+
+    def unlink_cached(self):
+        """
+        If there is a locally-cached TAR, unlink it.  If there's already NOT a copy, log a warning
+        (just once) but don't raise.
+        """
+        match self.local_storage_type:
+            case LocalStorageType.SNAPSHOT_TGZ:
+                try:
+                    os.unlink(self.local_filepath_tgz)
+                    self.local_storage_type = LocalStorageType.UNCACHED
+                except FileNotFoundError:
+                    if type(self).warned_unlink_cached_none_found < 1:
+                        logger.warning(f'file already does not exist (warning only once): {self}')
+                    type(self).warned_unlink_cached_none_found += 1
+            case LocalStorageType.UNCACHED:
+                if type(self).warned_file_already_does_not_exist < 1:
+                    logger.warning(f'file already does not exist (warning only once): {self}')
+                type(self).warned_file_already_does_not_exist += 1
+            case _:
+                raise ValueError(f'unexpected value of local_storage_type: {self}')
+
+    # --- JSON-only operations that are invalid on a snapshot TAR --------------------------------
+
+    @property
+    def json_data_cache(self):
+        raise TypeError(
+            'a snapshot TAR is not a JSON document; read it via validate_tar()/extract_summary_file()'
+        )
+
+    def write_json(self, data: dict | list):
+        raise TypeError('write_json() is not valid on a snapshot TAR (SnapshotFile)')
+
+    def bzip2_compress(self):
+        raise TypeError('a snapshot TAR is already gzip-compressed and must not be bz2-compressed')
+
+    def infer_local_storage_type(self, path) -> LocalStorageType:
+        raise TypeError(
+            'infer_local_storage_type() does JSON/bz2 sniffing, invalid on a snapshot TAR; a '
+            'SnapshotFile cache is always LocalStorageType.SNAPSHOT_TGZ'
+        )
+
+    def open_for_read(self):
+        raise TypeError(
+            'open_for_read() returns a JSON/bz2 handle; read a snapshot TAR via validate_tar()/'
+            'extract_summary_file() (which use tarfile)'
+        )
+
+    # --- domain I/O (still stubbed; later task) -------------------------------------------------
+
+    def validate_tar(self) -> bool:
+        """
+        Open the locally-cached TAR and iterate every member, reading each fully, to confirm the
+        archive is complete and not truncated.
+
+        Intended to replace the tarfile validation block in
+        ArchiveSiteCrawler.fetch_tar_file_and_extract_summary(), which today logs and skips (returns
+        None) on failure rather than raising.
+
+        TODO: implement.  Decide and document the contract on a bad TAR (raise vs. return False) and
+          align the crawler rebase with that choice.
+        """
+        raise NotImplementedError('SnapshotFile.validate_tar() is a stub; see TODO')
+
+    def extract_summary_file(self, output_dir: Path = None) -> 'SnapshotSummaryFile':
+        """
+        Extract the rpki-client output JSON member (matching summary_member_re) from the
+        locally-cached TAR and return a SnapshotSummaryFile wrapping it.
+
+        Intended to replace ArchiveSiteCrawler.extract_matching_file_from_tar() plus the
+        summary-handling that follows it.  The returned SnapshotSummaryFile shares this snapshot's
+        datetimestamp and, once the SQL files table exists, should link back to this SnapshotFile's
+        row.
+
+        TODO: implement.  Confirm exactly one member matches summary_member_re; decide whether the
+          extracted summary is written UNCOMPRESSED or BZIP2 and where (output_dir vs.
+          local_storage_dir).  Import SnapshotSummaryFile at implementation time (no import cycle:
+          snapshot_summary_file imports only data_file_super, not this module).
+        """
+        raise NotImplementedError('SnapshotFile.extract_summary_file() is a stub; see TODO')

--- a/python/rpkilog/rpkilog/snapshot_file.py
+++ b/python/rpkilog/rpkilog/snapshot_file.py
@@ -7,12 +7,12 @@ that we extract into a SnapshotSummaryFile.  This class is the planned home for 
 *file* concerns currently scattered through archive_site_crawler.py: filename/datetime derivation,
 validating the TAR, extracting the summary, and uploading the TAR to S3.
 
-STATUS: the storage model is implemented.  A snapshot's cached bytes are an opaque gzipped TAR
+STATUS: implemented.  A snapshot's cached bytes are an opaque gzipped TAR
 (LocalStorageType.SNAPSHOT_TGZ) held at local_filepath_tgz.  Operations that only make sense for a
 JSON document raise (see the type-invalid overrides below), the S3 round-trip moves the TAR
-byte-for-byte under its '.tgz' key, and local-cache cleanup unlinks the TAR.  The domain I/O methods
-(validate_tar, extract_summary_file) remain stubs, and archive_site_crawler is NOT yet rebased onto
-this class; both are a separate, later task.
+byte-for-byte under its '.tgz' key, local-cache cleanup unlinks the TAR, validate_tar() checks the
+archive is readable, and extract_summary_file() pulls the rpki-client JSON out as a
+SnapshotSummaryFile.  archive_site_crawler is rebased onto this class.
 
 Design notes:
   - SnapshotFile does NOT acquire bytes from, or parse the URLs of, the archive site.  Acquisition
@@ -35,22 +35,11 @@ TODO(sql-files-table): When the SQL files table lands, a SnapshotFile should map
   explicit s3_url so the instance never consults the process-global default base URL (DataFileSuper
   already supports known-url instances).  Decide whether to_sql_row()/from_sql_row() belong here or
   on DataFileSuper, shared by all file types.
-
-TODO(crawler-rebase): the later archive_site_crawler.py refactor should replace these in-line pieces
-  with the methods here:
-    - S3-key / filename regex matching of 'rpki-...Z.tgz'      -> infer_datetimestamp_from_path()
-    - destination filename derivation                          -> default_filename
-    - day-page archive-URL parsing + streaming requests.get()  -> stays in the crawler / future
-      download                                                    ArchiveSite; construct a SnapshotFile
-                                                                  from the downloaded temp path
-                                                                  (local_filepath_tgz + SNAPSHOT_TGZ)
-    - tarfile readability check                                -> validate_tar()
-    - extract_matching_file_from_tar() + summary handling      -> extract_summary_file()
-    - cls.s3.upload_file(...) of the TAR to the snapshot bucket -> s3_upload()
 """
 import logging
 import os
 import shutil
+import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
 import re
@@ -60,6 +49,7 @@ import dateutil.parser
 
 from rpkilog.data_file_super import DataFileSuper
 from rpkilog.local_storage_type import LocalStorageType
+from rpkilog.snapshot_summary_file import SnapshotSummaryFile
 
 logger = logging.getLogger(__name__)
 
@@ -85,12 +75,11 @@ class SnapshotFile(DataFileSuper):
     ]
 
     # Regex matching the rpki-client summary JSON member inside a snapshot TAR, e.g.
-    # 'rpki-20211121T000709Z/output/rpki-client.json'.  Group 1 is the YYYYMMDDTHHMMSSZ stamp and
-    # group 2 is '.json'.  archive_site_crawler.extract_matching_file_from_tar() owns this today;
-    # extract_summary_file() will use it once implemented.
-    summary_member_re = r'^rpki-(\d{8}T\d{6}Z)/output/rpki-client(\.json)$'
+    # 'rpki-20211121T000709Z/output/rpki-client.json'.  Used by extract_summary_file().
+    summary_member_re = r'^rpki-(\d{8}T\d{6}Z)/output/rpki-client\.json$'
 
-    def __init__(self, *args, source_url: str = None, local_filepath_tgz: Path = None, **kwargs):
+    def __init__(self, *args, source_url: str | None = None, local_filepath_tgz: Path | None = None,
+                 **kwargs):
         """
         Add source_url and local_filepath_tgz on top of the DataFileSuper constructor.
 
@@ -266,35 +255,75 @@ class SnapshotFile(DataFileSuper):
             'extract_summary_file() (which use tarfile)'
         )
 
-    # --- domain I/O (still stubbed; later task) -------------------------------------------------
+    # --- TAR-content operations (read the already-acquired local .tgz) ---------------------------
 
     def validate_tar(self) -> bool:
         """
-        Open the locally-cached TAR and iterate every member, reading each fully, to confirm the
-        archive is complete and not truncated.
+        Confirm the locally-cached TAR is complete and readable.
 
-        Intended to replace the tarfile validation block in
-        ArchiveSiteCrawler.fetch_tar_file_and_extract_summary(), which today logs and skips (returns
-        None) on failure rather than raising.
-
-        TODO: implement.  Decide and document the contract on a bad TAR (raise vs. return False) and
-          align the crawler rebase with that choice.
+        Opens the '.tgz' and reads every regular member in full; a truncated or corrupt archive
+        raises somewhere in tarfile, which we catch.  Contract: returns True when the whole archive
+        reads cleanly, and False (logging the cause) when it does not — it does NOT raise on a bad
+        TAR, so the crawler can simply skip-and-continue (a later run re-downloads it).  Raises only
+        when there is no local '.tgz' to validate.
         """
-        raise NotImplementedError('SnapshotFile.validate_tar() is a stub; see TODO')
+        if self.local_storage_type != LocalStorageType.SNAPSHOT_TGZ:
+            raise ValueError(f'cannot validate a snapshot without a local .tgz file: {self}')
+        retval = True
+        try:
+            with tarfile.open(self.local_filepath_tgz, 'r:*') as tar_reader:
+                for member in tar_reader.getmembers():
+                    if not member.isfile():
+                        continue
+                    member_reader = tar_reader.extractfile(member)
+                    while member_reader.read(1024 * 64):
+                        pass
+        except Exception:
+            logger.exception(f'TAR_FAILED_VALIDATION {self}')
+            retval = False
+        return retval
 
-    def extract_summary_file(self, output_dir: Path = None) -> 'SnapshotSummaryFile':
+    def extract_summary_file(self, output_dir: Path | None = None) -> SnapshotSummaryFile:
         """
         Extract the rpki-client output JSON member (matching summary_member_re) from the
-        locally-cached TAR and return a SnapshotSummaryFile wrapping it.
+        locally-cached TAR and return an UNCOMPRESSED SnapshotSummaryFile wrapping it.
 
-        Intended to replace ArchiveSiteCrawler.extract_matching_file_from_tar() plus the
-        summary-handling that follows it.  The returned SnapshotSummaryFile shares this snapshot's
-        datetimestamp and, once the SQL files table exists, should link back to this SnapshotFile's
-        row.
-
-        TODO: implement.  Confirm exactly one member matches summary_member_re; decide whether the
-          extracted summary is written UNCOMPRESSED or BZIP2 and where (output_dir vs.
-          local_storage_dir).  Import SnapshotSummaryFile at implementation time (no import cycle:
-          snapshot_summary_file imports only data_file_super, not this module).
+        Exactly one member must match summary_member_re (raises KeyError if none, ValueError if more
+        than one).  The summary is written under output_dir (default: this snapshot's
+        local_storage_dir) and left UNCOMPRESSED; SnapshotSummaryFile.s3_upload() bzip2-compresses on
+        upload.  The returned summary is named by THIS snapshot's datetimestamp (not the in-TAR member
+        path), tying summary identity to the snapshot it came from.
         """
-        raise NotImplementedError('SnapshotFile.extract_summary_file() is a stub; see TODO')
+        if self.local_storage_type != LocalStorageType.SNAPSHOT_TGZ:
+            raise ValueError(f'cannot extract a summary without a local .tgz file: {self}')
+        if output_dir is None:
+            output_dir = self.local_storage_dir
+        member_re = re.compile(self.summary_member_re)
+        matched_member_name = None
+        summary_bytes: bytes | None = None
+        with tarfile.open(self.local_filepath_tgz, 'r:*') as tar_reader:
+            for member in tar_reader.getmembers():
+                if not member.isfile():
+                    continue
+                if not member_re.match(member.name):
+                    continue
+                if matched_member_name is not None:
+                    raise ValueError(
+                        f'expected exactly one member matching {self.summary_member_re!r} in '
+                        f'{self.local_filepath_tgz}; found multiple: '
+                        f'{matched_member_name} and {member.name}'
+                    )
+                extracted = tar_reader.extractfile(member)
+                if extracted is None:
+                    continue
+                matched_member_name = member.name
+                summary_bytes = extracted.read()
+        if summary_bytes is None:
+            raise KeyError(
+                f'no member matching {self.summary_member_re!r} in {self.local_filepath_tgz}'
+            )
+        summary = SnapshotSummaryFile(datetimestamp=self.datetimestamp, local_storage_dir=output_dir)
+        with open(summary.local_filepath_uncompressed, 'wb') as summary_fh:
+            summary_fh.write(summary_bytes)
+        summary.local_storage_type = LocalStorageType.UNCOMPRESSED
+        return summary

--- a/python/rpkilog/tests/test_snapshot_file.py
+++ b/python/rpkilog/tests/test_snapshot_file.py
@@ -1,0 +1,210 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from rpkilog.cleanup_policy import CleanupPolicy
+from rpkilog.local_storage_type import LocalStorageType
+from rpkilog.snapshot_file import SnapshotFile
+
+GOLDEN_DT = datetime(2021, 11, 21, 0, 7, 9, tzinfo=timezone.utc)
+GOLDEN_NAME = 'rpki-20211121T000709Z.tgz'
+
+
+# --- Unit tests: filename / path derivation (no disk I/O, no S3) ---
+
+def test_filename_generation():
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert f.default_filename == GOLDEN_NAME
+
+
+def test_local_filepath_tgz():
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    assert str(f.local_filepath_tgz) == f'/tmp/{GOLDEN_NAME}'
+
+
+def test_json_form_path_properties_raise():
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    with pytest.raises(TypeError):
+        _ = f.local_filepath_uncompressed
+    with pytest.raises(TypeError):
+        _ = f.local_filepath_bz2
+
+
+def test_repr_does_not_raise():
+    # repr_attrs drops the raising JSON-path properties; __repr__ must stay usable in error messages.
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    rendered = repr(f)
+    assert 'SnapshotFile(' in rendered
+    assert 'local_filepath_tgz' in rendered
+
+
+# --- Unit tests: parsers ---
+
+def test_infer_datetimestamp_from_path():
+    assert SnapshotFile.infer_datetimestamp_from_path(Path(GOLDEN_NAME)) == GOLDEN_DT
+
+
+def test_infer_datetimestamp_rejects_summary_filename():
+    with pytest.raises(ValueError):
+        SnapshotFile.infer_datetimestamp_from_path(Path('20211121T000709Z.json.bz2'))
+
+
+def test_infer_datetimestamp_rejects_vrpdiff_filename():
+    with pytest.raises(ValueError):
+        SnapshotFile.infer_datetimestamp_from_path(Path('20211121T000709Z.vrpdiff.json.bz2'))
+
+
+def test_source_url_is_stored_as_provenance():
+    # SnapshotFile records source_url but never fetches it; the crawler sets it on construction.
+    url = f'https://example.com/2021/11/21/{GOLDEN_NAME}'
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, source_url=url, local_storage_dir=Path('/tmp'))
+    assert f.source_url == url
+
+
+# --- Unit tests: default S3 key derivation (no network) ---
+
+def test_s3_url_set_to_default_has_no_bz2_suffix(monkeypatch):
+    # isolate the process-global base-url classvar (auto-restored on teardown)
+    monkeypatch.setattr(SnapshotFile, '_default_s3_base_url', None, raising=False)
+    SnapshotFile.default_s3_base_url_set('s3://example-bucket/prefix/')
+    f = SnapshotFile(datetimestamp=GOLDEN_DT)
+    url = f.s3_url_set_to_default()
+    assert url == f's3://example-bucket/prefix/{GOLDEN_NAME}'
+    assert not url.endswith('.bz2')
+    assert f.s3_path == f'prefix/{GOLDEN_NAME}'
+
+
+# --- Unit tests: JSON-only operations are invalid on a snapshot TAR ---
+
+def test_json_only_operations_raise():
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    with pytest.raises(TypeError):
+        _ = f.json_data_cache
+    with pytest.raises(TypeError):
+        f.write_json({'roas': []})
+    with pytest.raises(TypeError):
+        f.bzip2_compress()
+    with pytest.raises(TypeError):
+        f.infer_local_storage_type(Path('/tmp/x'))
+    with pytest.raises(TypeError):
+        f.open_for_read()
+
+
+# --- Unit tests: domain I/O methods are still stubs ---
+
+def test_domain_io_methods_are_stubs():
+    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
+    with pytest.raises(NotImplementedError):
+        f.validate_tar()
+    with pytest.raises(NotImplementedError):
+        f.extract_summary_file()
+
+
+# --- Unit tests: local-cache handling (tmp_path only) ---
+
+def test_unlink_cached_removes_tgz(tmp_path):
+    p = tmp_path / GOLDEN_NAME
+    p.write_bytes(b'fake-tgz')
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT,
+        local_filepath_tgz=p,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+    )
+    f.unlink_cached()
+    assert not p.exists()
+    assert f.local_storage_type == LocalStorageType.UNCACHED
+
+
+def test_context_manager_cleans_up_tgz(tmp_path):
+    p = tmp_path / GOLDEN_NAME
+    p.write_bytes(b'fake-tgz')
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT,
+        local_filepath_tgz=p,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+        cleanup_policy=CleanupPolicy.CLEANUP_ALWAYS,
+    )
+    with f:
+        assert p.exists()
+    assert not p.exists()
+    assert f.local_storage_type == LocalStorageType.UNCACHED
+
+
+def test_write_to_path_copies_local_tgz(tmp_path):
+    p = tmp_path / GOLDEN_NAME
+    p.write_bytes(b'hello-tgz')
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT,
+        local_filepath_tgz=p,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+    )
+    dest = tmp_path / 'out.tgz'
+    f.write_to_path(dest)
+    assert dest.read_bytes() == b'hello-tgz'
+
+
+def test_cleanup_raises_on_unhandled_state(tmp_path):
+    # SnapshotFile._cleanup_local_cache rejects a JSON storage state it should never carry.
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT,
+        local_storage_dir=tmp_path,
+        local_storage_type=LocalStorageType.BZIP2,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+    )
+    with pytest.raises(ValueError):
+        f._cleanup_local_cache()
+
+
+def test_base_cleanup_safety_net_raises(tmp_path):
+    # DataFileSuper._cleanup_local_cache now raises on an unhandled storage state (e.g. a base
+    # subclass that has not been taught about SNAPSHOT_TGZ).  s3_stored is False so the destructor's
+    # CLEANUP_IF_IN_S3 policy will not re-invoke cleanup during GC.
+    from rpkilog.snapshot_summary_file import SnapshotSummaryFile
+    f = SnapshotSummaryFile(datetimestamp=GOLDEN_DT, local_storage_dir=tmp_path)
+    f.local_storage_type = LocalStorageType.SNAPSHOT_TGZ
+    with pytest.raises(ValueError):
+        f._cleanup_local_cache()
+
+
+# --- S3 tests (require live AWS credentials) ---
+
+@pytest.mark.slow
+def test_s3_roundtrip(tmp_path, s3_test_bucket, s3_base_url_factory):
+    payload = b'\x1f\x8b' + b'pretend-gzipped-tarball-bytes' * 16
+    local_copy = tmp_path / GOLDEN_NAME
+    local_copy.write_bytes(payload)
+    # Point the class at a run-unique base URL; the object derives its key from base + filename.
+    s3_base_url_factory(SnapshotFile, 'test_snapshot_file')
+
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT,
+        local_filepath_tgz=local_copy,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+    )
+    test_key = None
+    try:
+        f.s3_upload()
+        assert f.s3_exists()
+        assert f.s3_path.endswith(GOLDEN_NAME)
+        assert not f.s3_path.endswith('.bz2')
+        test_key = f.s3_path
+
+        download_path = tmp_path / 'downloaded.tgz'
+        f2 = SnapshotFile(
+            datetimestamp=GOLDEN_DT,
+            local_filepath_tgz=download_path,
+            local_storage_type=LocalStorageType.UNCACHED,
+            s3_url=f.s3_url,
+            cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+        )
+        f2.s3_download()
+        assert f2.local_storage_type == LocalStorageType.SNAPSHOT_TGZ
+        # uploaded byte-for-byte: the downloaded TAR must equal the original payload
+        assert download_path.read_bytes() == payload
+    finally:
+        if test_key is not None:
+            s3_test_bucket.Object(test_key).delete()

--- a/python/rpkilog/tests/test_snapshot_file.py
+++ b/python/rpkilog/tests/test_snapshot_file.py
@@ -1,3 +1,6 @@
+import io
+import json
+import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -6,9 +9,28 @@ import pytest
 from rpkilog.cleanup_policy import CleanupPolicy
 from rpkilog.local_storage_type import LocalStorageType
 from rpkilog.snapshot_file import SnapshotFile
+from rpkilog.snapshot_summary_file import SnapshotSummaryFile
 
 GOLDEN_DT = datetime(2021, 11, 21, 0, 7, 9, tzinfo=timezone.utc)
 GOLDEN_NAME = 'rpki-20211121T000709Z.tgz'
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent.parent / 'test_data'
+# Golden snapshot TAR (large): internal member is rpki-20260111T194523Z/output/rpki-client.json
+GOLDEN_SNAPSHOT_TGZ = TEST_DATA_DIR / 'rpkiclient_snapshot_20260111T194523Z.tgz'
+GOLDEN_SNAPSHOT_DT = datetime(2026, 1, 11, 19, 45, 23, tzinfo=timezone.utc)
+
+
+def _make_tgz(path, members):
+    """Write a gzipped tar at path containing {member_name: bytes} entries."""
+    with tarfile.open(path, 'w:gz') as tf:
+        for member_name, payload in members.items():
+            info = tarfile.TarInfo(member_name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+
+
+def _summary_member_name(dt=GOLDEN_DT):
+    return f'rpki-{dt.strftime("%Y%m%dT%H%M%SZ")}/output/rpki-client.json'
 
 
 # --- Unit tests: filename / path derivation (no disk I/O, no S3) ---
@@ -89,16 +111,6 @@ def test_json_only_operations_raise():
         f.infer_local_storage_type(Path('/tmp/x'))
     with pytest.raises(TypeError):
         f.open_for_read()
-
-
-# --- Unit tests: domain I/O methods are still stubs ---
-
-def test_domain_io_methods_are_stubs():
-    f = SnapshotFile(datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'))
-    with pytest.raises(NotImplementedError):
-        f.validate_tar()
-    with pytest.raises(NotImplementedError):
-        f.extract_summary_file()
 
 
 # --- Unit tests: local-cache handling (tmp_path only) ---
@@ -208,3 +220,106 @@ def test_s3_roundtrip(tmp_path, s3_test_bucket, s3_base_url_factory):
     finally:
         if test_key is not None:
             s3_test_bucket.Object(test_key).delete()
+
+
+# --- validate_tar (synthetic tars, no network) ---
+
+def test_validate_tar_good(tmp_path):
+    tgz = tmp_path / GOLDEN_NAME
+    _make_tgz(tgz, {_summary_member_name(): b'{}', 'rpki-x/output/rpki-client.log': b'log'})
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT, local_filepath_tgz=tgz,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+    )
+    assert f.validate_tar() is True
+
+
+def test_validate_tar_corrupt_returns_false(tmp_path):
+    bad = tmp_path / GOLDEN_NAME
+    bad.write_bytes(b'this is not a gzipped tar')
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT, local_filepath_tgz=bad,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+    )
+    assert f.validate_tar() is False
+
+
+def test_validate_tar_requires_local_tgz():
+    f = SnapshotFile(
+        datetimestamp=GOLDEN_DT, local_storage_dir=Path('/tmp'),
+        local_storage_type=LocalStorageType.UNCACHED,
+    )
+    with pytest.raises(ValueError):
+        f.validate_tar()
+
+
+# --- extract_summary_file (synthetic tars, no network) ---
+
+def test_extract_summary_file(tmp_path):
+    summary_payload = json.dumps({'metadata': {'buildtime': '2021-11-21T00:07:09Z'}, 'roas': []}).encode()
+    tgz = tmp_path / GOLDEN_NAME
+    _make_tgz(tgz, {
+        _summary_member_name(): summary_payload,
+        'rpki-20211121T000709Z/output/rpki-client.log': b'log',
+    })
+    snapshot = SnapshotFile(
+        datetimestamp=GOLDEN_DT, local_filepath_tgz=tgz,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+    )
+    summary = snapshot.extract_summary_file(output_dir=tmp_path)
+    assert isinstance(summary, SnapshotSummaryFile)
+    assert summary.local_storage_type == LocalStorageType.UNCOMPRESSED
+    # named by the snapshot's datetimestamp, not the in-TAR member path
+    assert summary.local_filepath_uncompressed.name == '20211121T000709Z.json'
+    assert json.loads(summary.local_filepath_uncompressed.read_bytes()) == json.loads(summary_payload)
+
+
+def test_extract_summary_file_no_member_raises(tmp_path):
+    tgz = tmp_path / GOLDEN_NAME
+    _make_tgz(tgz, {'rpki-20211121T000709Z/output/other.json': b'{}'})
+    snapshot = SnapshotFile(
+        datetimestamp=GOLDEN_DT, local_filepath_tgz=tgz,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+    )
+    with pytest.raises(KeyError):
+        snapshot.extract_summary_file(output_dir=tmp_path)
+
+
+def test_extract_summary_file_multiple_members_raises(tmp_path):
+    tgz = tmp_path / GOLDEN_NAME
+    _make_tgz(tgz, {
+        'rpki-20211121T000709Z/output/rpki-client.json': b'{}',
+        'rpki-20211121T000710Z/output/rpki-client.json': b'{}',
+    })
+    snapshot = SnapshotFile(
+        datetimestamp=GOLDEN_DT, local_filepath_tgz=tgz,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+    )
+    with pytest.raises(ValueError):
+        snapshot.extract_summary_file(output_dir=tmp_path)
+
+
+# --- Golden snapshot TAR (large; reads test_data/ only, no S3) ---
+
+@pytest.mark.slow
+def test_validate_tar_golden(tmp_path):
+    snapshot = SnapshotFile(
+        datetimestamp=GOLDEN_SNAPSHOT_DT, local_filepath_tgz=GOLDEN_SNAPSHOT_TGZ,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+    )
+    assert snapshot.validate_tar() is True
+
+
+@pytest.mark.slow
+def test_extract_summary_file_golden(tmp_path):
+    snapshot = SnapshotFile(
+        datetimestamp=GOLDEN_SNAPSHOT_DT, local_filepath_tgz=GOLDEN_SNAPSHOT_TGZ,
+        local_storage_type=LocalStorageType.SNAPSHOT_TGZ,
+        cleanup_policy=CleanupPolicy.CLEANUP_NEVER,
+    )
+    summary = snapshot.extract_summary_file(output_dir=tmp_path)
+    assert summary.local_filepath_uncompressed.name == '20260111T194523Z.json'
+    data = json.loads(summary.local_filepath_uncompressed.read_bytes())
+    assert 'metadata' in data
+    assert 'roas' in data

--- a/python/rpkilog/tests/test_snapshot_file.py
+++ b/python/rpkilog/tests/test_snapshot_file.py
@@ -19,6 +19,14 @@ TEST_DATA_DIR = Path(__file__).parent.parent.parent.parent / 'test_data'
 GOLDEN_SNAPSHOT_TGZ = TEST_DATA_DIR / 'rpkiclient_snapshot_20260111T194523Z.tgz'
 GOLDEN_SNAPSHOT_DT = datetime(2026, 1, 11, 19, 45, 23, tzinfo=timezone.utc)
 
+# The golden snapshot TAR is too large to commit to git, so it exists only on developer machines.
+# Tests that read it skip cleanly where it is absent (e.g. GitHub CI).  The synthetic-tar tests above
+# cover the same code paths without it.
+skipif_no_golden_snapshot = pytest.mark.skipif(
+    not GOLDEN_SNAPSHOT_TGZ.exists(),
+    reason='large snapshot TAR fixture not committed to git; present only locally',
+)
+
 
 def _make_tgz(path, members):
     """Write a gzipped tar at path containing {member_name: bytes} entries."""
@@ -302,6 +310,7 @@ def test_extract_summary_file_multiple_members_raises(tmp_path):
 # --- Golden snapshot TAR (large; reads test_data/ only, no S3) ---
 
 @pytest.mark.slow
+@skipif_no_golden_snapshot
 def test_validate_tar_golden(tmp_path):
     snapshot = SnapshotFile(
         datetimestamp=GOLDEN_SNAPSHOT_DT, local_filepath_tgz=GOLDEN_SNAPSHOT_TGZ,
@@ -312,6 +321,7 @@ def test_validate_tar_golden(tmp_path):
 
 
 @pytest.mark.slow
+@skipif_no_golden_snapshot
 def test_extract_summary_file_golden(tmp_path):
     snapshot = SnapshotFile(
         datetimestamp=GOLDEN_SNAPSHOT_DT, local_filepath_tgz=GOLDEN_SNAPSHOT_TGZ,

--- a/python/rpkilog/uv.lock
+++ b/python/rpkilog/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "rpkilog"
-version = "0.26060702"
+version = "0.26062101"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
In preparation for reconciliation support, this refactors archive_site_crawler.py onto DataFileSuper to reduce duplicate code patterns.

Two new CLI options are added to more clearly invoke rpkilog-archive-site-crawler with an explicit datetimestamp range:

```
  --filename-datetime-min FILENAME_DATETIME_MIN
                        Only process snapshots whose filename datetime is >= this (optional)
  --filename-datetime-max FILENAME_DATETIME_MAX
                        Only process snapshots whose filename datetime is <= this (optional)
```

An invocation to backfill an old date range looks like:

```shell
rpkilog-archive-site-crawler \
  --s3-snapshot-bucket-name rpkilog-snapshot \
  --s3-snapshot-summary-bucket-name rpkilog-snapshot-summary \
  --site-root <site base url here> \
  --start-date 2024-02-27 \
  --job-max-downloads 100000 \
  --filename-datetime-min 20240228T140700Z \
  --filename-datetime-max 20240228T235959Z
```