### PR TITLE
GH-81: add mariadb dev VM

### DIFF
--- a/.mise/tasks/replace-mariadb-1.rpkilog.dev.sh
+++ b/.mise/tasks/replace-mariadb-1.rpkilog.dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Replace mariadb-1 VM (dev)"
+#MISE dir="terraform/root/dev"
+set -euo pipefail
+# No STS token to replace yet; a future revision may add one (e.g. for copying
+# data from the prod SQL DB into the dev DB).
+terraform apply \
+  -replace=incus_instance.mariadb_1

--- a/python/rpkilog/pyproject.toml
+++ b/python/rpkilog/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'rpkilog'
-version = '0.26062101'
+version = '0.26062201'
 authors = [{ name = 'Jeff Wheeler', email = 'jeffsw6@gmail.com' }]
 dependencies = [
     "boto3",

--- a/python/rpkilog/uv.lock
+++ b/python/rpkilog/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "rpkilog"
-version = "0.26062101"
+version = "0.26062201"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/terraform/module/mariadb_userdata/mariadb_userdata.tf
+++ b/terraform/module/mariadb_userdata/mariadb_userdata.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 1.15"
+}
+
+variable "console_password_plaintext" {
+  description = "Console login password for the jsw user"
+  type        = string
+}
+
+variable "fqdn" {
+  description = "Fully qualified domain name for the VM (e.g. mariadb-1.rpkilog.dev); sets the system hostname and shell prompt"
+  type        = string
+  default     = null
+}
+
+variable "db_admin_username" {
+  description = "MariaDB admin user created at first boot, authenticating with username/password from any host. Used for dev access and, later, by the Atlas and petoju/mysql Terraform providers (the dev incus VM has no RDS IAM auth, so access is username/password)."
+  type        = string
+}
+
+variable "db_admin_password" {
+  description = "Password for the MariaDB admin user"
+  type        = string
+}
+
+locals {
+  user_data_mariadb = {
+    console_password_plaintext = nonsensitive(var.console_password_plaintext)
+    db_admin_username          = var.db_admin_username
+    db_admin_password          = nonsensitive(var.db_admin_password)
+    fqdn                       = var.fqdn
+  }
+}
+
+output "userdata" {
+  description = "plaintext user data for the mariadb VM"
+  type        = string
+  value       = templatefile("${path.module}/mariadb_userdata.yml.tftpl", local.user_data_mariadb)
+}

--- a/terraform/module/mariadb_userdata/mariadb_userdata.tf
+++ b/terraform/module/mariadb_userdata/mariadb_userdata.tf
@@ -23,11 +23,23 @@ variable "db_admin_password" {
   type        = string
 }
 
+variable "db_developer_username" {
+  description = "MariaDB convenience user created at first boot, restricted to @localhost but fully privileged. Its credentials are written to a world-readable /etc/mysql client config so any OS user can run `mariadb` with no password prompt."
+  type        = string
+}
+
+variable "db_developer_password" {
+  description = "Password for the MariaDB developer convenience user"
+  type        = string
+}
+
 locals {
   user_data_mariadb = {
     console_password_plaintext = nonsensitive(var.console_password_plaintext)
     db_admin_username          = var.db_admin_username
     db_admin_password          = nonsensitive(var.db_admin_password)
+    db_developer_username      = var.db_developer_username
+    db_developer_password      = nonsensitive(var.db_developer_password)
     fqdn                       = var.fqdn
   }
 }

--- a/terraform/module/mariadb_userdata/mariadb_userdata.yml.tftpl
+++ b/terraform/module/mariadb_userdata/mariadb_userdata.yml.tftpl
@@ -56,11 +56,31 @@ write_files:
     permissions: "0755"
     content: |4
         #!/bin/bash -e
-        # Ensure MariaDB is running, then create the dev admin user.  root on the VM
-        # authenticates to MariaDB over the unix socket, so no password is needed here.
+        # Create the DB users, then install a global client config so any OS user can
+        # run `mariadb` with no password.  We connect as root over the unix socket with
+        # --no-defaults so the developer client config written below can't interfere
+        # with this bootstrap (or with anything that connects before the user exists).
         systemctl enable --now mariadb
-        mysql <<'SQL'
+        mysql --no-defaults --user=root --socket=/run/mysqld/mysqld.sock <<'SQL'
+        -- Admin user: username/password from any host; for dev access and, later, the
+        -- Atlas / petoju-mysql Terraform providers.
         CREATE USER IF NOT EXISTS '${db_admin_username}'@'%' IDENTIFIED BY '${db_admin_password}';
         GRANT ALL PRIVILEGES ON *.* TO '${db_admin_username}'@'%' WITH GRANT OPTION;
+        -- Developer user: fully privileged but restricted to localhost (socket), so the
+        -- preinstalled credentials below are useless off-box even with bind-address 0.0.0.0.
+        CREATE USER IF NOT EXISTS '${db_developer_username}'@'localhost' IDENTIFIED BY '${db_developer_password}';
+        GRANT ALL PRIVILEGES ON *.* TO '${db_developer_username}'@'localhost' WITH GRANT OPTION;
         FLUSH PRIVILEGES;
         SQL
+        # World-readable on purpose: every OS user gets passwordless local access via the
+        # localhost-only developer account.  Written only after the account exists, so it
+        # can't disrupt the MariaDB package postinst (which runs earlier in cloud-init).
+        cat > /etc/mysql/mariadb.conf.d/99-rpkilog-developer-client.cnf <<'CNF'
+        # Dev convenience: the bare `mariadb` / `mysql` client connects as the
+        # fully-privileged, localhost-only developer account with no prompt.
+        [client]
+        user = ${db_developer_username}
+        password = ${db_developer_password}
+        socket = /run/mysqld/mysqld.sock
+        CNF
+        chmod 0644 /etc/mysql/mariadb.conf.d/99-rpkilog-developer-client.cnf

--- a/terraform/module/mariadb_userdata/mariadb_userdata.yml.tftpl
+++ b/terraform/module/mariadb_userdata/mariadb_userdata.yml.tftpl
@@ -1,0 +1,66 @@
+#cloud-config
+%{~ if fqdn != null }
+fqdn: ${fqdn}
+prefer_fqdn_over_hostname: true
+%{~ endif }
+# MariaDB data lives on the root filesystem; this dev VM has no separate data disk.
+package_reboot_if_required: true
+package_update: true
+package_upgrade: true
+packages:
+  - ca-certificates
+  - curl
+  - htop
+  - incus-agent
+  - mariadb-client
+  - mariadb-server
+  - openssh-server
+  - ssh-import-id
+ssh_pwauth: false
+users:
+  - name: jsw
+    groups: adm,sudo
+    lock_passwd: false
+    plain_text_passwd: "${console_password_plaintext}"
+    shell: /usr/bin/bash
+    sudo: "ALL=(ALL) NOPASSWD: ALL"
+    ssh_authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4k8nVaS9Ns+8jZ1C97eUcOvkFw6NOXS8e4xxG6XEH1l9PDluOCxAqgCvdKxX9ZhFvwW1SCSWuN95WrM7u/9p0flOX7DZFYld053ClWxMZZ4ZtKj8XWnmDU4LLXSmUWaKddW9pHZHvxfEFu+wCcnUiJM4NgS4owfaIGC3IOIXVrxsoNuoKyTQS9pRa5+3sMC3rHK8oWPkleJGO+cs8AxuetRtHS/ZHwshsyI27ROC/nIxZ7ZeKXf3g/jxEpbxI9LNFnocuUmeoNpndBFYND1ujwiHZvoWxx4ByiTRDNJDHJWdnJpz8rOmnoHeHFqV8F/I5CRG9Dh7aq5vd9LWdrkqb jeffsw6@gmail.com boomer 2013-05-28
+write_files:
+  - path: /etc/profile.d/rpkilog_prompt.sh
+    permissions: '0644'
+    content: |4
+        # rpkilog: single source of truth for the interactive prompt.
+        # Colored, with fully-qualified hostname (\H).
+        PS1='\[\033[01;32m\]\u@\H\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+  - path: /etc/skel/.bashrc
+    append: true
+    content: |4
+        # rpkilog: prompt is managed in /etc/profile.d/rpkilog_prompt.sh
+        [ -r /etc/profile.d/rpkilog_prompt.sh ] && . /etc/profile.d/rpkilog_prompt.sh
+  - path: /root/.bashrc
+    append: true
+    content: |4
+        # rpkilog: prompt is managed in /etc/profile.d/rpkilog_prompt.sh
+        [ -r /etc/profile.d/rpkilog_prompt.sh ] && . /etc/profile.d/rpkilog_prompt.sh
+  - path: /etc/mysql/mariadb.conf.d/99-rpkilog.cnf
+    owner: root:root
+    permissions: '0644'
+    content: |4
+        [mysqld]
+        # Listen on all interfaces so dev clients and the Atlas / petoju-mysql Terraform
+        # providers can reach MariaDB over the rpkilog.dev network.  This is a dev VM with
+        # no RDS IAM auth, so access is username/password only.
+        bind-address = 0.0.0.0
+  - path: /var/lib/cloud/scripts/per-once/100_mariadb_bootstrap.sh
+    permissions: "0755"
+    content: |4
+        #!/bin/bash -e
+        # Ensure MariaDB is running, then create the dev admin user.  root on the VM
+        # authenticates to MariaDB over the unix socket, so no password is needed here.
+        systemctl enable --now mariadb
+        mysql <<'SQL'
+        CREATE USER IF NOT EXISTS '${db_admin_username}'@'%' IDENTIFIED BY '${db_admin_password}';
+        GRANT ALL PRIVILEGES ON *.* TO '${db_admin_username}'@'%' WITH GRANT OPTION;
+        FLUSH PRIVILEGES;
+        SQL

--- a/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
+++ b/terraform/module/opensearch_1_userdata/opensearch_1_userdata.yml.tftpl
@@ -119,7 +119,19 @@ write_files:
   - path: /etc/profile.d/rpkilog_prompt.sh
     permissions: '0644'
     content: |4
-        PS1='\u@\H:\w\$ '
+        # rpkilog: single source of truth for the interactive prompt.
+        # Colored, with fully-qualified hostname (\H).
+        PS1='\[\033[01;32m\]\u@\H\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+  - path: /etc/skel/.bashrc
+    append: true
+    content: |4
+        # rpkilog: prompt is managed in /etc/profile.d/rpkilog_prompt.sh
+        [ -r /etc/profile.d/rpkilog_prompt.sh ] && . /etc/profile.d/rpkilog_prompt.sh
+  - path: /root/.bashrc
+    append: true
+    content: |4
+        # rpkilog: prompt is managed in /etc/profile.d/rpkilog_prompt.sh
+        [ -r /etc/profile.d/rpkilog_prompt.sh ] && . /etc/profile.d/rpkilog_prompt.sh
   - path: /usr/local/bin/install_opensearch.sh
     permissions: "0755"
     content: |4

--- a/terraform/module/rpkiclient_userdata/rpkiclient_userdata.yml.tftpl
+++ b/terraform/module/rpkiclient_userdata/rpkiclient_userdata.yml.tftpl
@@ -67,7 +67,19 @@ write_files:
   - path: /etc/profile.d/rpkilog_prompt.sh
     permissions: '0644'
     content: |4
-        PS1='\u@\H:\w\$ '
+        # rpkilog: single source of truth for the interactive prompt.
+        # Colored, with fully-qualified hostname (\H).
+        PS1='\[\033[01;32m\]\u@\H\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+  - path: /etc/skel/.bashrc
+    append: true
+    content: |4
+        # rpkilog: prompt is managed in /etc/profile.d/rpkilog_prompt.sh
+        [ -r /etc/profile.d/rpkilog_prompt.sh ] && . /etc/profile.d/rpkilog_prompt.sh
+  - path: /root/.bashrc
+    append: true
+    content: |4
+        # rpkilog: prompt is managed in /etc/profile.d/rpkilog_prompt.sh
+        [ -r /etc/profile.d/rpkilog_prompt.sh ] && . /etc/profile.d/rpkilog_prompt.sh
   - path: /root/.aws/config
     owner: root:root
     permissions: '0600'

--- a/terraform/root/dev/mariadb_1.tf
+++ b/terraform/root/dev/mariadb_1.tf
@@ -1,0 +1,71 @@
+# Dev MariaDB for the snapshot-tracking database (GH-81).  RDS in prod; an incus VM here.
+# MariaDB data lives on the VM's root filesystem — the dataset is modest and dev disk is cheap.
+
+locals {
+  mariadb_1_admin_username = "rpkilog_admin"
+}
+
+resource "random_password" "mariadb_1_console" {
+  length  = 14
+  lower   = true
+  numeric = true
+  special = false
+  upper   = true
+}
+
+resource "random_password" "mariadb_1_admin" {
+  length  = 24
+  lower   = true
+  numeric = true
+  special = false
+  upper   = true
+}
+
+output "mariadb_1_console_password" {
+  description = "mariadb-1 VM console login password for the jsw user"
+  value       = nonsensitive(random_password.mariadb_1_console.result)
+}
+
+output "mariadb_1_admin_username" {
+  description = "MariaDB admin (dev access) username on mariadb-1.rpkilog.dev"
+  value       = local.mariadb_1_admin_username
+}
+
+output "mariadb_1_admin_password" {
+  description = "MariaDB admin (dev access) password on mariadb-1.rpkilog.dev"
+  value       = nonsensitive(random_password.mariadb_1_admin.result)
+}
+
+module "userdata_mariadb_1" {
+  source                     = "../../module/mariadb_userdata"
+  console_password_plaintext = nonsensitive(random_password.mariadb_1_console.result)
+  db_admin_username          = local.mariadb_1_admin_username
+  db_admin_password          = nonsensitive(random_password.mariadb_1_admin.result)
+  fqdn                       = "mariadb-1.rpkilog.dev"
+}
+
+# https://registry.terraform.io/providers/lxc/incus/latest/docs/resources/instance
+resource "incus_instance" "mariadb_1" {
+  name  = "mariadb-1"
+  type  = "virtual-machine"
+  image = "images:ubuntu/24.04/cloud"
+  config = {
+    "boot.autostart"       = true
+    "boot.autostart.delay" = 150
+    # 2 vCPU, no core pinning (a bare count rather than a pinned cpuset like "10,11").
+    "limits.cpu"     = "2"
+    "limits.memory"  = "2GB"
+    "user.user-data" = module.userdata_mariadb_1.userdata
+  }
+  wait_for {
+    type = "ipv4"
+  }
+}
+
+resource "aws_route53_record" "mariadb_1_A" {
+  zone_id = data.aws_route53_zone.rpkilog_dev.zone_id
+  name    = "mariadb-1"
+  type    = "A"
+  ttl     = 300
+  records = [incus_instance.mariadb_1.ipv4_address]
+}

--- a/terraform/root/dev/mariadb_1.tf
+++ b/terraform/root/dev/mariadb_1.tf
@@ -2,7 +2,8 @@
 # MariaDB data lives on the VM's root filesystem — the dataset is modest and dev disk is cheap.
 
 locals {
-  mariadb_1_admin_username = "rpkilog_admin"
+  mariadb_1_admin_username     = "rpkilog_admin"
+  mariadb_1_developer_username = "developer"
 }
 
 resource "random_password" "mariadb_1_console" {
@@ -14,6 +15,14 @@ resource "random_password" "mariadb_1_console" {
 }
 
 resource "random_password" "mariadb_1_admin" {
+  length  = 24
+  lower   = true
+  numeric = true
+  special = false
+  upper   = true
+}
+
+resource "random_password" "mariadb_1_developer" {
   length  = 24
   lower   = true
   numeric = true
@@ -36,11 +45,23 @@ output "mariadb_1_admin_password" {
   value       = nonsensitive(random_password.mariadb_1_admin.result)
 }
 
+output "mariadb_1_developer_username" {
+  description = "MariaDB localhost-only, fully-privileged convenience user; its credentials are preinstalled in /etc/mysql on the VM, so a bare `mariadb` works for any OS user without a password"
+  value       = local.mariadb_1_developer_username
+}
+
+output "mariadb_1_developer_password" {
+  description = "Password for the MariaDB developer convenience user (also written to /etc/mysql/mariadb.conf.d on the VM)"
+  value       = nonsensitive(random_password.mariadb_1_developer.result)
+}
+
 module "userdata_mariadb_1" {
   source                     = "../../module/mariadb_userdata"
   console_password_plaintext = nonsensitive(random_password.mariadb_1_console.result)
   db_admin_username          = local.mariadb_1_admin_username
   db_admin_password          = nonsensitive(random_password.mariadb_1_admin.result)
+  db_developer_username      = local.mariadb_1_developer_username
+  db_developer_password      = nonsensitive(random_password.mariadb_1_developer.result)
   fqdn                       = "mariadb-1.rpkilog.dev"
 }
 


### PR DESCRIPTION
* add mariadb dev VM with admin and developer credentials available
* fix & improve shell prompt on VMs to more easily tell the difference between dev & prod
